### PR TITLE
fix: support binary download for file attachments without corruption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,7 +458,7 @@ Include a `Co-Authored-By` trailer naming the specific model that authored the w
 - Use a single merged import from each module — avoid two `import` statements from the same path.
 - Test files are in `src/tests/` (flat, not a `unit/` subdirectory) and excluded from the build by `tsconfig.json`.
 - `dist/` is **gitignored** (not committed). Run `npm run build` to compile before running or deploying.
-- The MCP SDK handles serialization; just return plain objects from tool handlers.
+- The MCP SDK handles serialization; just return plain objects from tool handlers (via the `defineTool` helper, which JSON-stringifies the result into a text block). For tools that must emit native content blocks instead — e.g. `download_attachment` returns an `image` block for image attachments — use `defineContentTool` and return a ready-made `{ content: [...] }` result.
 - Firefly III API is REST; pagination is via query params (`limit`, `page`).
 - `/summary/basic` returns a dict (`Record<string, {...}>`), not an array — use `cleanSummary`.
 - Insight endpoints (`/insight/expense/category`, `/insight/income/category`) return flat arrays with no JSON:API envelope — pass through directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `create_account` now accepts `account_role`, which Firefly III requires when creating asset accounts.
-- Fix binary attachment corruption in `download_attachment` tool by handling array buffer and returning structured Base64 payload.
+- `download_attachment` no longer corrupts binary files (PDFs, images): content is read as raw bytes and Base64-encoded instead of decoded as UTF-8 text. Images are now returned as a native MCP image block (rendered by the client); other files as their filename, MIME type, and Base64 content.
 
 ## [0.1.1] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `create_account` now accepts `account_role`, which Firefly III requires when creating asset accounts.
+- Fix binary attachment corruption in `download_attachment` tool by handling array buffer and returning structured Base64 payload.
 
 ## [0.1.1] - 2026-05-23
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ The server exposes `GET /.well-known/oauth-authorization-server` (no auth requir
 | `update_attachment` | Update attachment metadata |
 | `delete_attachment` | Delete an attachment and its file data. This action cannot be undone. |
 | `upload_attachment` | Upload base64-encoded file content for an existing attachment record (step 2 of 2) |
-| `download_attachment` | Download the raw content of an attachment as text |
+| `download_attachment` | Download an attachment by ID; images are returned as a rendered image, other files as their filename, MIME type, and Base64 content |
 
 </details>
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -146,4 +146,27 @@ export class FireflyClient {
     });
     return response.text();
   }
+
+  async getBinary(
+    path: string,
+    params?: QueryParams,
+  ): Promise<{ data: Buffer; contentType: string; filename: string }> {
+    const response = await this.rawFetch(this.buildUrl(path, params), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.getToken()}`,
+        Accept: '*/*',
+      },
+    });
+    const arrayBuffer = await response.arrayBuffer();
+    const data = Buffer.from(arrayBuffer);
+    const contentType = response.headers.get('Content-Type') ?? 'application/octet-stream';
+    const contentDisposition = response.headers.get('Content-Disposition') ?? '';
+    let filename = 'file';
+    const match = contentDisposition.match(/filename\*?=(?:utf-8'')?["']?([^"';]+)["']?/i);
+    if (match?.[1]) {
+      filename = decodeURIComponent(match[1]);
+    }
+    return { data, contentType, filename };
+  }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,29 @@ function parseFieldErrors(body: string): string | null {
   return null;
 }
 
+/**
+ * Extract a filename from a Content-Disposition header. Handles the RFC 5987
+ * extended form (`filename*=UTF-8''…`, percent-decoded) and the plain
+ * `filename=` form (quoted or unquoted, used verbatim). Returns "file" when no
+ * usable filename is present. `decodeURIComponent` is applied only to the
+ * extended form — a plain filename containing a literal "%" must not be decoded.
+ */
+export function parseContentDispositionFilename(header: string | null | undefined): string {
+  if (!header) return 'file';
+  const extended = header.match(/filename\*=(?:[\w-]+'[^']*')?([^;]+)/i);
+  if (extended?.[1]) {
+    const raw = extended[1].trim().replace(/^["']|["']$/g, '');
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw; // malformed percent-encoding — fall back to the raw value
+    }
+  }
+  const plain = header.match(/filename=("([^"]*)"|([^;]+))/i);
+  const value = (plain?.[2] ?? plain?.[3] ?? '').trim();
+  return value || 'file';
+}
+
 export function formatError(err: unknown): string {
   if (err instanceof FireflyError) {
     if (err.status === 400) {
@@ -161,12 +184,7 @@ export class FireflyClient {
     const arrayBuffer = await response.arrayBuffer();
     const data = Buffer.from(arrayBuffer);
     const contentType = response.headers.get('Content-Type') ?? 'application/octet-stream';
-    const contentDisposition = response.headers.get('Content-Disposition') ?? '';
-    let filename = 'file';
-    const match = contentDisposition.match(/filename\*?=(?:utf-8'')?["']?([^"';]+)["']?/i);
-    if (match?.[1]) {
-      filename = decodeURIComponent(match[1]);
-    }
+    const filename = parseContentDispositionFilename(response.headers.get('Content-Disposition'));
     return { data, contentType, filename };
   }
 }

--- a/src/tests/attachments.test.ts
+++ b/src/tests/attachments.test.ts
@@ -142,14 +142,22 @@ describe('uploadAttachment', () => {
 });
 
 describe('downloadAttachment', () => {
-  it('calls getText on /attachments/:id/download', async () => {
+  it('calls getBinary on /attachments/:id/download and returns base64 content with metadata', async () => {
     const mockFull = {
       ...mockClient,
-      getText: vi.fn().mockResolvedValueOnce('receipt content'),
+      getBinary: vi.fn().mockResolvedValueOnce({
+        data: Buffer.from('receipt content'),
+        contentType: 'application/pdf',
+        filename: 'receipt.pdf',
+      }),
     } as unknown as FireflyClient;
     const result = await downloadAttachment(mockFull, '7');
-    expect(mockFull.getText).toHaveBeenCalledWith('/attachments/7/download');
-    expect(result).toBe('receipt content');
+    expect(mockFull.getBinary).toHaveBeenCalledWith('/attachments/7/download');
+    expect(result).toEqual({
+      content_base64: Buffer.from('receipt content').toString('base64'),
+      contentType: 'application/pdf',
+      filename: 'receipt.pdf',
+    });
   });
 });
 

--- a/src/tests/attachments.test.ts
+++ b/src/tests/attachments.test.ts
@@ -4,6 +4,7 @@ import {
   createAttachment,
   deleteAttachment,
   downloadAttachment,
+  downloadAttachmentContent,
   fetchAttachment,
   fetchAttachments,
   registerAttachmentTools,
@@ -155,9 +156,42 @@ describe('downloadAttachment', () => {
     expect(mockFull.getBinary).toHaveBeenCalledWith('/attachments/7/download');
     expect(result).toEqual({
       content_base64: Buffer.from('receipt content').toString('base64'),
-      contentType: 'application/pdf',
+      content_type: 'application/pdf',
       filename: 'receipt.pdf',
     });
+  });
+});
+
+describe('downloadAttachmentContent', () => {
+  it('returns a native image block for image attachments', () => {
+    const result = downloadAttachmentContent({
+      content_base64: 'YWJj',
+      content_type: 'image/png',
+      filename: 'receipt.png',
+    });
+    expect(result).toEqual({ content: [{ type: 'image', data: 'YWJj', mimeType: 'image/png' }] });
+  });
+
+  it('strips Content-Type parameters when choosing the image MIME type', () => {
+    const result = downloadAttachmentContent({
+      content_base64: 'YWJj',
+      content_type: 'image/jpeg; charset=binary',
+      filename: 'photo.jpg',
+    });
+    expect(result).toEqual({ content: [{ type: 'image', data: 'YWJj', mimeType: 'image/jpeg' }] });
+  });
+
+  it('returns a text block with metadata for non-image attachments', () => {
+    const result = downloadAttachmentContent({
+      content_base64: 'YWJj',
+      content_type: 'application/pdf',
+      filename: 'receipt.pdf',
+    });
+    expect(result.content[0]).toMatchObject({ type: 'text' });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('filename: receipt.pdf');
+    expect(text).toContain('content_type: application/pdf');
+    expect(text).toContain('content_base64: YWJj');
   });
 });
 
@@ -175,6 +209,28 @@ describe('handler smoke — attachments', () => {
     const client = { get: vi.fn().mockRejectedValueOnce(new Error('Network error')) } as unknown as FireflyClient;
     registerAttachmentTools(server, client);
     const result = await handlers.get('get_attachments')!({});
+    expect(result).toMatchObject({ isError: true });
+  });
+
+  it('download_attachment handler returns an image block for image attachments', async () => {
+    const { server, handlers } = createMockServer();
+    const client = {
+      getBinary: vi.fn().mockResolvedValueOnce({
+        data: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+        contentType: 'image/png',
+        filename: 'receipt.png',
+      }),
+    } as unknown as FireflyClient;
+    registerAttachmentTools(server, client);
+    const result = await handlers.get('download_attachment')!({ id: '7' });
+    expect(result).toMatchObject({ content: [{ type: 'image', mimeType: 'image/png' }] });
+  });
+
+  it('download_attachment handler returns isError on failure', async () => {
+    const { server, handlers } = createMockServer();
+    const client = { getBinary: vi.fn().mockRejectedValueOnce(new Error('Network error')) } as unknown as FireflyClient;
+    registerAttachmentTools(server, client);
+    const result = await handlers.get('download_attachment')!({ id: '7' });
     expect(result).toMatchObject({ isError: true });
   });
 });

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -254,6 +254,34 @@ describe('FireflyClient write methods', () => {
     );
   });
 
+  it('getBinary returns buffer and metadata from headers', async () => {
+    const headers = new Headers({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': 'attachment; filename="receipt.pdf"',
+    });
+    const body = new Uint8Array([1, 2, 3, 4]);
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(body, { status: 200, headers }));
+    const client = new FireflyClient('https://firefly.example.com', 'my-token');
+    const result = await client.getBinary('/attachments/7/download');
+    expect(result.data).toEqual(Buffer.from(body));
+    expect(result.contentType).toBe('application/pdf');
+    expect(result.filename).toBe('receipt.pdf');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://firefly.example.com/api/v1/attachments/7/download',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('getBinary fallback values for headers', async () => {
+    const body = new Uint8Array([1, 2, 3, 4]);
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(body, { status: 200 }));
+    const client = new FireflyClient('https://firefly.example.com', 'my-token');
+    const result = await client.getBinary('/attachments/7/download');
+    expect(result.data).toEqual(Buffer.from(body));
+    expect(result.contentType).toBe('application/octet-stream');
+    expect(result.filename).toBe('file');
+  });
+
   it('serializes string[] params as repeated query params', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response('csv data', { status: 200 }));
     const client = new FireflyClient('https://firefly.example.com', 'my-token');

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { FireflyClient, FireflyError, formatError } from '../client.js';
+import { FireflyClient, FireflyError, formatError, parseContentDispositionFilename } from '../client.js';
 
 describe('FireflyClient', () => {
   beforeEach(() => {
@@ -282,6 +282,16 @@ describe('FireflyClient write methods', () => {
     expect(result.filename).toBe('file');
   });
 
+  it('getBinary preserves non-text bytes through base64 round-trip', async () => {
+    // Bytes that are NOT valid UTF-8 — the original getText()-based code corrupted these.
+    const body = new Uint8Array([0xff, 0xfe, 0x00, 0x80, 0x7f]);
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(body, { status: 200 }));
+    const client = new FireflyClient('https://firefly.example.com', 'my-token');
+    const result = await client.getBinary('/attachments/7/download');
+    expect(Uint8Array.from(result.data)).toEqual(body);
+    expect(Buffer.from(result.data.toString('base64'), 'base64')).toEqual(Buffer.from(body));
+  });
+
   it('serializes string[] params as repeated query params', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response('csv data', { status: 200 }));
     const client = new FireflyClient('https://firefly.example.com', 'my-token');
@@ -334,5 +344,44 @@ describe('formatError — updated cases', () => {
     expect(err.message).not.toContain('secret=abc');
     expect(err.message).not.toContain('?page=1');
     expect(err.message).toContain('/api/v1/accounts');
+  });
+});
+
+describe('parseContentDispositionFilename', () => {
+  it('returns "file" when the header is absent', () => {
+    expect(parseContentDispositionFilename(null)).toBe('file');
+    expect(parseContentDispositionFilename(undefined)).toBe('file');
+  });
+
+  it('parses a plain quoted filename', () => {
+    expect(parseContentDispositionFilename('attachment; filename="receipt.pdf"')).toBe('receipt.pdf');
+  });
+
+  it('parses an unquoted filename and stops at the next parameter', () => {
+    expect(parseContentDispositionFilename('attachment; filename=receipt.pdf; size=123')).toBe('receipt.pdf');
+  });
+
+  it('does not throw and does not decode a literal "%" in a plain filename', () => {
+    expect(parseContentDispositionFilename('attachment; filename="50%_off_invoice.pdf"')).toBe('50%_off_invoice.pdf');
+  });
+
+  it('preserves a quoted filename that contains a semicolon', () => {
+    expect(parseContentDispositionFilename('attachment; filename="a;b.pdf"')).toBe('a;b.pdf');
+  });
+
+  it('percent-decodes the RFC 5987 extended form', () => {
+    expect(parseContentDispositionFilename("attachment; filename*=UTF-8''%E2%82%AC%20receipt.pdf")).toBe(
+      '€ receipt.pdf',
+    );
+  });
+
+  it('prefers the extended form over the plain form when both are present', () => {
+    expect(
+      parseContentDispositionFilename('attachment; filename="fallback.pdf"; filename*=UTF-8\'\'real%20name.pdf'),
+    ).toBe('real name.pdf');
+  });
+
+  it('falls back to the raw value when the extended form is malformed', () => {
+    expect(parseContentDispositionFilename("attachment; filename*=UTF-8''bad%name.pdf")).toBe('bad%name.pdf');
   });
 });

--- a/src/tools/_helpers.ts
+++ b/src/tools/_helpers.ts
@@ -39,4 +39,33 @@ export function defineTool(
   });
 }
 
+/** A pre-built MCP tool result. Used by tools that return native content blocks
+ * (e.g. an `image` block) instead of letting {@link defineTool} JSON-stringify a
+ * plain value into a single text block. */
+export type ContentResult = {
+  content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>;
+  isError?: boolean;
+};
+
+/**
+ * Like {@link defineTool}, but the handler returns a ready-made MCP result
+ * (content blocks) rather than a plain value. Error handling is identical:
+ * thrown errors become an `isError` text block via {@link formatError}.
+ */
+export function defineContentTool(
+  server: McpServer,
+  name: string,
+  config: ToolConfig,
+  fetch: (args: Record<string, unknown>) => Promise<ContentResult>,
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server as any).registerTool(name, config, async (args: Record<string, unknown>) => {
+    try {
+      return await fetch(args);
+    } catch (err) {
+      return { content: [{ type: 'text' as const, text: formatError(err) }], isError: true };
+    }
+  });
+}
+
 export const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD');

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -58,8 +58,16 @@ export async function uploadAttachment(
   return { uploaded: true, id };
 }
 
-export async function downloadAttachment(client: FireflyClient, id: string): Promise<string> {
-  return client.getText(`/attachments/${id}/download`);
+export async function downloadAttachment(
+  client: FireflyClient,
+  id: string,
+): Promise<{ content_base64: string; contentType: string; filename: string }> {
+  const { data, contentType, filename } = await client.getBinary(`/attachments/${id}/download`);
+  return {
+    content_base64: data.toString('base64'),
+    contentType,
+    filename,
+  };
 }
 
 export function registerAttachmentTools(server: McpServer, client: FireflyClient): void {
@@ -181,7 +189,7 @@ export function registerAttachmentTools(server: McpServer, client: FireflyClient
     {
       title: 'Download Attachment',
       description:
-        'Download the raw content of an attachment as text. Useful for reading receipts or notes. Use get_attachments to find valid IDs.',
+        'Download a file attachment (such as an invoice, PDF, or image receipt) by its ID. Returns the filename, MIME content type, and the file data encoded as a Base64 string. Use get_attachments to find valid IDs.',
       inputSchema: {
         id: z.string().describe('Attachment ID'),
       },

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -10,7 +10,7 @@ import {
   unwrapSingle,
 } from '../transform.js';
 import { DELETE_ANNOTATIONS, READ_ANNOTATIONS, UPDATE_ANNOTATIONS, WRITE_ANNOTATIONS } from './_annotations.js';
-import { defineTool } from './_helpers.js';
+import { type ContentResult, defineContentTool, defineTool } from './_helpers.js';
 
 // ---- Attachment fetch + CRUD ----
 
@@ -58,15 +58,38 @@ export async function uploadAttachment(
   return { uploaded: true, id };
 }
 
-export async function downloadAttachment(
-  client: FireflyClient,
-  id: string,
-): Promise<{ content_base64: string; contentType: string; filename: string }> {
+export interface DownloadedAttachment {
+  content_base64: string;
+  content_type: string;
+  filename: string;
+}
+
+export async function downloadAttachment(client: FireflyClient, id: string): Promise<DownloadedAttachment> {
   const { data, contentType, filename } = await client.getBinary(`/attachments/${id}/download`);
   return {
     content_base64: data.toString('base64'),
-    contentType,
+    content_type: contentType,
     filename,
+  };
+}
+
+/**
+ * Map a downloaded attachment to an MCP result. Image attachments are returned
+ * as a native `image` content block so clients can render them; everything else
+ * is returned as a text block carrying the filename, MIME type, and Base64 data.
+ */
+export function downloadAttachmentContent(file: DownloadedAttachment): ContentResult {
+  const mimeType = file.content_type.split(';')[0].trim();
+  if (mimeType.startsWith('image/')) {
+    return { content: [{ type: 'image', data: file.content_base64, mimeType }] };
+  }
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `filename: ${file.filename}\ncontent_type: ${file.content_type}\ncontent_base64: ${file.content_base64}`,
+      },
+    ],
   };
 }
 
@@ -183,18 +206,18 @@ export function registerAttachmentTools(server: McpServer, client: FireflyClient
     ({ id, content_base64 }) => uploadAttachment(client, id as string, Buffer.from(content_base64 as string, 'base64')),
   );
 
-  defineTool(
+  defineContentTool(
     server,
     'download_attachment',
     {
       title: 'Download Attachment',
       description:
-        'Download a file attachment (such as an invoice, PDF, or image receipt) by its ID. Returns the filename, MIME content type, and the file data encoded as a Base64 string. Use get_attachments to find valid IDs.',
+        'Download a file attachment (such as an invoice, PDF, or image receipt) by its ID. Image attachments are returned as a rendered image; other files are returned as their filename, MIME content type, and Base64-encoded content. Use get_attachments to find valid IDs.',
       inputSchema: {
         id: z.string().describe('Attachment ID'),
       },
       annotations: READ_ANNOTATIONS,
     },
-    ({ id }) => downloadAttachment(client, id as string),
+    async ({ id }) => downloadAttachmentContent(await downloadAttachment(client, id as string)),
   );
 }


### PR DESCRIPTION
### Summary
This PR fixes the binary attachment corruption issue in the `download_attachment` tool.

### Details
- Added a `getBinary` helper in `FireflyClient` (`src/client.ts`) that reads responses using `.arrayBuffer()` and resolves file metadata from headers (`Content-Type` and `Content-Disposition`).
- Updated `downloadAttachment` in `src/tools/attachments.ts` to return `{ content_base64, contentType, filename }` so the client receives a structured base64 representation.
- Added comprehensive unit tests in `src/tests/client.test.ts` and `src/tests/attachments.test.ts`.