### PR TITLE
feat: support filter and preset configurations via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,15 @@ MCP_BASE_URL=https://mcp.example.com
 
 # Optional (both transports): emit verbose autocomplete tracing to stderr.
 # FIREFLY_DEBUG=true
+
+# Optional tool filtering (fallbacks for --preset / --groups / --read-only).
+# A CLI flag always takes precedence over these. MCP_PRESET and MCP_GROUPS are
+# mutually exclusive.
+# Presets: minimal, default, budgeting, insights, automation, full
+# MCP_PRESET=default
+# Groups: accounts, transactions, budgets, categories, bills, piggy-banks,
+#   reports, rules, recurring, attachments, currencies, exports,
+#   object-groups, transaction-links
+# MCP_GROUPS=accounts,transactions
+# Accepts "true" or "1" (case-insensitive); any other value is ignored.
+# MCP_READ_ONLY=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,13 @@ In HTTP mode, the Bearer token is resolved per-request from the Authorization he
 FIREFLY_DEBUG     Set to "true" or "1" to emit verbose autocomplete tracing to stderr. Off by default.
 ```
 
+**Tool-filtering fallbacks (both transports)** for the `--preset`/`--groups`/`--read-only` flags. The CLI flag always wins when both are set.
+```
+MCP_PRESET      String. Named preset; same values as --preset. Mutually exclusive with MCP_GROUPS.
+MCP_GROUPS      String. Comma-separated group names; same values as --groups. Empty/whitespace-only is treated as unset.
+MCP_READ_ONLY   "true" or "1" (case-insensitive, trimmed) enables read-only mode; any other value is ignored.
+```
+
 Store credentials in `.env` file (which is gitignored). The `.env.example` template shows what's needed.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Nightly integration tests run automatically against a live Firefly III instance (latest release) via GitHub Actions, covering the transform layer, six tool groups (accounts, transactions, budgets, categories, currencies, tags, summary), and full account and transaction CRUD cycles.
 - [Experimental] Add autocompletion support for account, budget, and category parameters using the MCP Completion API. Note: Standard tool argument completions are not supported by the MCP specification directly, so this is implemented via native Prompts (`category-transactions`, `account-transactions`, `budget-transactions`). This is supported primarily by clients that support Prompt argument autocomplete (such as Claude Code) and may not function in other MCP clients. Suggestions are cached in memory (60s TTL) and scoped per authenticated user, so the cache is safe under multi-user HTTP/OAuth deployments. Set `FIREFLY_DEBUG=true` for verbose autocomplete tracing on stderr.
+- Support tool presets, group filters, and read-only mode via environment variables (`MCP_PRESET`, `MCP_GROUPS`, `MCP_READ_ONLY`).
 
 ### Fixed
 - `create_account` now accepts `account_role`, which Firefly III requires when creating asset accounts.

--- a/README.md
+++ b/README.md
@@ -591,6 +591,27 @@ node dist/index.js --groups rules --read-only
 
 Without any filter flags the server registers all 140 tools (equivalent to `--preset full`).
 
+### Environment variable equivalents
+
+Each filter flag has an environment-variable fallback, which is convenient for the npm/stdio and Docker setups where there is no natural place to pass CLI flags. A CLI flag always takes precedence over its environment variable.
+
+| Variable | Equivalent flag | Example |
+|----------|-----------------|---------|
+| `MCP_PRESET` | `--preset <name>` | `MCP_PRESET=default` |
+| `MCP_GROUPS` | `--groups <list>` | `MCP_GROUPS=accounts,transactions` |
+| `MCP_READ_ONLY` | `--read-only` | `MCP_READ_ONLY=true` (also accepts `1`) |
+
+As with the flags, `MCP_PRESET` and `MCP_GROUPS` are mutually exclusive. For example, in a stdio MCP client config:
+
+```jsonc
+"env": {
+  "FIREFLY_URL": "https://your-firefly-instance.example.com",
+  "FIREFLY_TOKEN": "your-personal-access-token-here",
+  "MCP_PRESET": "default",
+  "MCP_READ_ONLY": "true"
+}
+```
+
 ---
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ docker run \
 
 `MCP_BASE_URL` is the externally reachable URL of your container — used to build OAuth redirect URIs. If omitted the server falls back to the `Host` request header, which is unreliable behind a reverse proxy.
 
+To limit which tools the container exposes (e.g. to save context or run read-only), add the filtering environment variables — there are no CLI flags to pass in Docker, so these are the way to configure it:
+
+```bash
+docker run \
+  -e FIREFLY_URL=https://your-firefly-instance.example.com \
+  -e FIREFLY_OAUTH_CLIENT_ID=your-client-id \
+  -e MCP_BASE_URL=https://mcp.example.com \
+  -e MCP_PRESET=default \
+  -e MCP_READ_ONLY=true \
+  -p 3000:3000 \
+  ghcr.io/daften/fireflyiii-mcp:latest
+```
+
+See [Filtering Tools](#filtering-tools) for the full list of presets, groups, and the precedence rules.
+
 Or with docker-compose (copy `docker-compose.yml` from the repo):
 
 ```bash
@@ -601,7 +616,9 @@ Each filter flag has an environment-variable fallback, which is convenient for t
 | `MCP_GROUPS` | `--groups <list>` | `MCP_GROUPS=accounts,transactions` |
 | `MCP_READ_ONLY` | `--read-only` | `MCP_READ_ONLY=true` (also accepts `1`) |
 
-As with the flags, `MCP_PRESET` and `MCP_GROUPS` are mutually exclusive. For example, in a stdio MCP client config:
+As with the flags, `MCP_PRESET` and `MCP_GROUPS` are mutually exclusive.
+
+In a stdio MCP client config:
 
 ```jsonc
 "env": {
@@ -610,6 +627,15 @@ As with the flags, `MCP_PRESET` and `MCP_GROUPS` are mutually exclusive. For exa
   "MCP_PRESET": "default",
   "MCP_READ_ONLY": "true"
 }
+```
+
+In Docker — where there are no CLI flags to pass — set them as container environment variables, either via `docker run -e MCP_PRESET=default …` (see [Docker setup](#option-3-docker--http-self-hosted)) or in `docker-compose.yml`, which already forwards them from your shell or `.env` file:
+
+```yaml
+environment:
+  MCP_PRESET: ${MCP_PRESET:-}
+  MCP_GROUPS: ${MCP_GROUPS:-}
+  MCP_READ_ONLY: ${MCP_READ_ONLY:-}
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,8 @@ services:
       FIREFLY_URL: ${FIREFLY_URL}
       FIREFLY_OAUTH_CLIENT_ID: ${FIREFLY_OAUTH_CLIENT_ID}
       MCP_BASE_URL: ${MCP_BASE_URL}
+      # Optional tool filtering (see README → Filtering Tools). Leave unset to load all 140 tools.
+      MCP_PRESET: ${MCP_PRESET:-}
+      MCP_GROUPS: ${MCP_GROUPS:-}
+      MCP_READ_ONLY: ${MCP_READ_ONLY:-}
     restart: unless-stopped

--- a/src/args.ts
+++ b/src/args.ts
@@ -8,6 +8,36 @@ export interface ParsedArgs {
   filterOptions: ToolFilterOptions;
 }
 
+/**
+ * Validate a preset name from either a CLI flag or an environment variable.
+ * `source` is appended to the error message (e.g. " from MCP_PRESET") to make
+ * misconfiguration easy to trace; pass "" for CLI flags.
+ */
+function validatePreset(val: string, source = ''): PresetName {
+  if (!(val in PRESETS)) {
+    throw new Error(`Unknown preset "${val}"${source}. Valid presets: ${Object.keys(PRESETS).join(', ')}`);
+  }
+  return val as PresetName;
+}
+
+/**
+ * Parse a comma-separated group list from a CLI flag or environment variable.
+ * Whitespace and empty entries are ignored; an unknown group throws. Returns
+ * an empty array when the input contains no usable group names.
+ */
+function parseGroups(raw: string, source = ''): ToolGroup[] {
+  const parts = raw
+    .split(',')
+    .map((g) => g.trim())
+    .filter(Boolean);
+  for (const g of parts) {
+    if (!(TOOL_GROUPS as readonly string[]).includes(g)) {
+      throw new Error(`Unknown group "${g}"${source}. Valid groups: ${TOOL_GROUPS.join(', ')}`);
+    }
+  }
+  return parts as ToolGroup[];
+}
+
 export function parseArgs(args: string[]): ParsedArgs {
   let transport: 'stdio' | 'http' = 'stdio';
   let host = '127.0.0.1';
@@ -36,49 +66,30 @@ export function parseArgs(args: string[]): ParsedArgs {
       port = parsed;
       portWasExplicit = true;
     } else if (arg === '--preset' && args[i + 1]) {
-      const val = args[++i];
-      if (!(val in PRESETS)) {
-        throw new Error(`Unknown preset "${val}". Valid presets: ${Object.keys(PRESETS).join(', ')}`);
-      }
-      preset = val as PresetName;
+      preset = validatePreset(args[++i]);
     } else if (arg === '--groups' && args[i + 1]) {
-      const parts = args[++i]
-        .split(',')
-        .map((g) => g.trim())
-        .filter(Boolean);
-      for (const g of parts) {
-        if (!(TOOL_GROUPS as readonly string[]).includes(g)) {
-          throw new Error(`Unknown group "${g}". Valid groups: ${TOOL_GROUPS.join(', ')}`);
-        }
-      }
-      groups = parts as ToolGroup[];
+      groups = parseGroups(args[++i]);
     } else if (arg === '--read-only') {
       readOnly = true;
     }
   }
 
-  if (preset === undefined && process.env.MCP_PRESET) {
-    const val = process.env.MCP_PRESET.trim();
-    if (!(val in PRESETS)) {
-      throw new Error(`Unknown preset "${val}" from MCP_PRESET. Valid presets: ${Object.keys(PRESETS).join(', ')}`);
-    }
-    preset = val as PresetName;
+  // Environment-variable fallbacks. CLI flags always take precedence: each is
+  // consulted only when the corresponding flag was omitted.
+  if (preset === undefined && process.env.MCP_PRESET?.trim()) {
+    preset = validatePreset(process.env.MCP_PRESET.trim(), ' from MCP_PRESET');
   }
 
   if (groups === undefined && process.env.MCP_GROUPS) {
-    const parts = process.env.MCP_GROUPS.split(',')
-      .map((g) => g.trim())
-      .filter(Boolean);
-    for (const g of parts) {
-      if (!(TOOL_GROUPS as readonly string[]).includes(g)) {
-        throw new Error(`Unknown group "${g}" from MCP_GROUPS. Valid groups: ${TOOL_GROUPS.join(', ')}`);
-      }
-    }
-    groups = parts as ToolGroup[];
+    const parsed = parseGroups(process.env.MCP_GROUPS, ' from MCP_GROUPS');
+    // An empty/whitespace-only value (e.g. "," or "  ") is treated as unset
+    // rather than "select no groups", which would silently register no tools.
+    if (parsed.length > 0) groups = parsed;
   }
 
-  if (!readOnly && process.env.MCP_READ_ONLY === 'true') {
-    readOnly = true;
+  if (!readOnly) {
+    const flag = process.env.MCP_READ_ONLY?.trim().toLowerCase();
+    if (flag === 'true' || flag === '1') readOnly = true;
   }
 
   if (preset !== undefined && groups !== undefined) {

--- a/src/args.ts
+++ b/src/args.ts
@@ -57,6 +57,30 @@ export function parseArgs(args: string[]): ParsedArgs {
     }
   }
 
+  if (preset === undefined && process.env.MCP_PRESET) {
+    const val = process.env.MCP_PRESET.trim();
+    if (!(val in PRESETS)) {
+      throw new Error(`Unknown preset "${val}" from MCP_PRESET. Valid presets: ${Object.keys(PRESETS).join(', ')}`);
+    }
+    preset = val as PresetName;
+  }
+
+  if (groups === undefined && process.env.MCP_GROUPS) {
+    const parts = process.env.MCP_GROUPS.split(',')
+      .map((g) => g.trim())
+      .filter(Boolean);
+    for (const g of parts) {
+      if (!(TOOL_GROUPS as readonly string[]).includes(g)) {
+        throw new Error(`Unknown group "${g}" from MCP_GROUPS. Valid groups: ${TOOL_GROUPS.join(', ')}`);
+      }
+    }
+    groups = parts as ToolGroup[];
+  }
+
+  if (!readOnly && process.env.MCP_READ_ONLY === 'true') {
+    readOnly = true;
+  }
+
   if (preset !== undefined && groups !== undefined) {
     throw new Error('Cannot use both --preset and --groups. Choose one.');
   }

--- a/src/tests/args.test.ts
+++ b/src/tests/args.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parseArgs } from '../args.js';
 
 describe('parseArgs — filter flags', () => {
@@ -73,5 +73,70 @@ describe('parseArgs — existing flags still work', () => {
 
   it('throws on invalid --port value', () => {
     expect(() => parseArgs(['--port', 'abc'])).toThrow(/--port must be/i);
+  });
+});
+
+describe('parseArgs — environment variables fallbacks', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.MCP_PRESET;
+    delete process.env.MCP_GROUPS;
+    delete process.env.MCP_READ_ONLY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('falls back to MCP_PRESET when --preset is omitted', () => {
+    process.env.MCP_PRESET = 'minimal';
+    const result = parseArgs([]);
+    expect(result.filterOptions.preset).toBe('minimal');
+  });
+
+  it('CLI --preset overrides MCP_PRESET', () => {
+    process.env.MCP_PRESET = 'minimal';
+    const result = parseArgs(['--preset', 'default']);
+    expect(result.filterOptions.preset).toBe('default');
+  });
+
+  it('falls back to MCP_GROUPS when --groups is omitted', () => {
+    process.env.MCP_GROUPS = 'rules,recurring';
+    const result = parseArgs([]);
+    expect(result.filterOptions.groups).toEqual(['rules', 'recurring']);
+  });
+
+  it('CLI --groups overrides MCP_GROUPS', () => {
+    process.env.MCP_GROUPS = 'rules,recurring';
+    const result = parseArgs(['--groups', 'accounts']);
+    expect(result.filterOptions.groups).toEqual(['accounts']);
+  });
+
+  it('falls back to MCP_READ_ONLY when --read-only is omitted', () => {
+    process.env.MCP_READ_ONLY = 'true';
+    const result = parseArgs([]);
+    expect(result.filterOptions.readOnly).toBe(true);
+  });
+
+  it('CLI --read-only takes precedence even if MCP_READ_ONLY is false/unset', () => {
+    process.env.MCP_READ_ONLY = 'false';
+    const result = parseArgs(['--read-only']);
+    expect(result.filterOptions.readOnly).toBe(true);
+  });
+
+  it('throws on invalid MCP_PRESET', () => {
+    process.env.MCP_PRESET = 'nonexistent';
+    expect(() => parseArgs([])).toThrow(/unknown preset/i);
+  });
+
+  it('throws on invalid MCP_GROUPS', () => {
+    process.env.MCP_GROUPS = 'accounts,fakething';
+    expect(() => parseArgs([])).toThrow(/unknown group.*fakething/i);
+  });
+
+  it('throws if both CLI preset and env groups are provided', () => {
+    process.env.MCP_GROUPS = 'accounts';
+    expect(() => parseArgs(['--preset', 'default'])).toThrow(/cannot use both --preset and --groups/i);
   });
 });

--- a/src/tests/args.test.ts
+++ b/src/tests/args.test.ts
@@ -139,4 +139,47 @@ describe('parseArgs — environment variables fallbacks', () => {
     process.env.MCP_GROUPS = 'accounts';
     expect(() => parseArgs(['--preset', 'default'])).toThrow(/cannot use both --preset and --groups/i);
   });
+
+  it('throws if both CLI groups and env preset are provided', () => {
+    process.env.MCP_PRESET = 'default';
+    expect(() => parseArgs(['--groups', 'accounts'])).toThrow(/cannot use both --preset and --groups/i);
+  });
+
+  it('accepts MCP_READ_ONLY=1 as truthy', () => {
+    process.env.MCP_READ_ONLY = '1';
+    expect(parseArgs([]).filterOptions.readOnly).toBe(true);
+  });
+
+  it('accepts MCP_READ_ONLY=TRUE case-insensitively', () => {
+    process.env.MCP_READ_ONLY = 'TRUE';
+    expect(parseArgs([]).filterOptions.readOnly).toBe(true);
+  });
+
+  it('ignores non-truthy MCP_READ_ONLY values', () => {
+    process.env.MCP_READ_ONLY = 'yes';
+    expect(parseArgs([]).filterOptions.readOnly).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace in MCP_PRESET', () => {
+    process.env.MCP_PRESET = '  minimal  ';
+    expect(parseArgs([]).filterOptions.preset).toBe('minimal');
+  });
+
+  it('trims whitespace around MCP_GROUPS entries', () => {
+    process.env.MCP_GROUPS = ' rules , recurring ';
+    expect(parseArgs([]).filterOptions.groups).toEqual(['rules', 'recurring']);
+  });
+
+  it('treats an empty/separator-only MCP_GROUPS as unset', () => {
+    process.env.MCP_GROUPS = ' , ';
+    expect(parseArgs([]).filterOptions.groups).toBeUndefined();
+  });
+
+  it('combines MCP_PRESET and MCP_READ_ONLY', () => {
+    process.env.MCP_PRESET = 'default';
+    process.env.MCP_READ_ONLY = 'true';
+    const result = parseArgs([]);
+    expect(result.filterOptions.preset).toBe('default');
+    expect(result.filterOptions.readOnly).toBe(true);
+  });
 });


### PR DESCRIPTION
### Summary
This PR adds support for configuring tool presets, groups, and read-only mode via standardized environment variables.

### Details
- Updated `src/args.ts` to automatically fallback to `process.env.MCP_PRESET`, `process.env.MCP_GROUPS` (comma-separated list), and `process.env.MCP_READ_ONLY === 'true'` when CLI flags are omitted.
- Added comprehensive unit tests in `src/tests/args.test.ts` to cover precedence and fallback behaviors.