### PR TITLE
chore: skip changelog check for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   changelog:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This PR refines the CHANGELOG check on the CI workflow to run only when the PR author is not `dependabot[bot]`. This prevents automated dependency updates from being blocked while maintaining the safety check for human contributors.