### PR TITLE
fix: enable CodeQL scanning for Dependabot branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,9 +12,6 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    # Dependabot PRs run with a restricted GITHUB_TOKEN that cannot write
-    # security-events — skip here; the push-to-main trigger covers merged code.
-    if: github.actor != 'dependabot[bot]'
     permissions:
       security-events: write
       packages: read


### PR DESCRIPTION
This PR enables CodeQL scans for Dependabot PRs by removing the `github.actor != 'dependabot[bot]'` job-level exclusion from the CodeQL workflow. Since the repository is a public repository, explicitly declaring the `security-events: write` permission is respected for Dependabot pull requests, allowing the CodeQL analysis to run successfully and satisfy the required status checks.