### PR TITLE
fix: send empty JSON body on rule trigger POSTs to avoid HTTP 415

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ dist/
 docs/.vitepress/dist
 docs/.vitepress/cache
 
+# Local-only Docker Compose override (build from source, machine-specific tweaks)
+docker-compose.override.yml
+docker-compose.override.yaml
+
 # Environment — never commit real secrets
 .env
 .env.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `trigger_rule` and `trigger_rule_group` no longer fail with HTTP 415. They sent a bodyless POST, so the client omitted the `Content-Type: application/json` header and Firefly III rejected the request. They now send an empty `{}` JSON body (trigger parameters are read from the query string), matching the other parameterless POST tools.
+
 ## [0.2.0] - 2026-05-30
 
 ### Added

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -174,6 +174,21 @@ describe('FireflyClient write methods', () => {
     expect(result).toEqual(responseData);
   });
 
+  it('post() sets Content-Type: application/json and serializes an empty {} body', async () => {
+    // Regression: a bodyless trigger POST must still carry Content-Type so Firefly does not 415.
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const client = new FireflyClient('https://firefly.example.com', 'token');
+    await client.post('/rule-groups/1/trigger', {}, { start: '2026-01-01' });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/rule-groups/1/trigger?start=2026-01-01'),
+      expect.objectContaining({
+        method: 'POST',
+        body: '{}',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+      }),
+    );
+  });
+
   it('put() sends PUT with JSON body and returns parsed response', async () => {
     const body = { name: 'Updated' };
     const responseData = { data: { id: '1', type: 'accounts', attributes: { name: 'Updated' }, links: {} } };

--- a/src/tests/rules.test.ts
+++ b/src/tests/rules.test.ts
@@ -257,23 +257,27 @@ describe('triggerRuleGroup', () => {
   it('posts to /rule-groups/:id/trigger with date filters', async () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(undefined);
     const result = await triggerRuleGroup(mockClient, '1', { start: '2026-01-01', end: '2026-12-31' });
-    expect(mockClient.post).toHaveBeenCalledWith('/rule-groups/1/trigger', undefined, {
-      start: '2026-01-01',
-      end: '2026-12-31',
-    });
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rule-groups/1/trigger',
+      {},
+      {
+        start: '2026-01-01',
+        end: '2026-12-31',
+      },
+    );
     expect(result).toEqual({ triggered: true, id: '1' });
   });
 
   it('passes empty query when no filters provided', async () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(undefined);
     await triggerRuleGroup(mockClient, '2', {});
-    expect(mockClient.post).toHaveBeenCalledWith('/rule-groups/2/trigger', undefined, {});
+    expect(mockClient.post).toHaveBeenCalledWith('/rule-groups/2/trigger', {}, {});
   });
 
   it('passes accounts array when provided', async () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(undefined);
     await triggerRuleGroup(mockClient, '3', { accounts: [1, 2] });
-    expect(mockClient.post).toHaveBeenCalledWith('/rule-groups/3/trigger', undefined, { 'accounts[]': [1, 2] });
+    expect(mockClient.post).toHaveBeenCalledWith('/rule-groups/3/trigger', {}, { 'accounts[]': [1, 2] });
   });
 });
 
@@ -281,23 +285,27 @@ describe('triggerRule', () => {
   it('posts to /rules/:id/trigger with date filters', async () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(undefined);
     const result = await triggerRule(mockClient, '10', { start: '2026-01-01', end: '2026-06-30' });
-    expect(mockClient.post).toHaveBeenCalledWith('/rules/10/trigger', undefined, {
-      start: '2026-01-01',
-      end: '2026-06-30',
-    });
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rules/10/trigger',
+      {},
+      {
+        start: '2026-01-01',
+        end: '2026-06-30',
+      },
+    );
     expect(result).toEqual({ triggered: true, id: '10' });
   });
 
   it('passes empty query when no filters provided', async () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(undefined);
     await triggerRule(mockClient, '10', {});
-    expect(mockClient.post).toHaveBeenCalledWith('/rules/10/trigger', undefined, {});
+    expect(mockClient.post).toHaveBeenCalledWith('/rules/10/trigger', {}, {});
   });
 
   it('passes accounts array when provided', async () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(undefined);
     await triggerRule(mockClient, '10', { accounts: [3, 4] });
-    expect(mockClient.post).toHaveBeenCalledWith('/rules/10/trigger', undefined, { 'accounts[]': [3, 4] });
+    expect(mockClient.post).toHaveBeenCalledWith('/rules/10/trigger', {}, { 'accounts[]': [3, 4] });
   });
 });
 

--- a/src/tools/rules.ts
+++ b/src/tools/rules.ts
@@ -137,7 +137,7 @@ export async function triggerRuleGroup(
   if (params.start) query.start = params.start;
   if (params.end) query.end = params.end;
   if (params.accounts?.length) query['accounts[]'] = params.accounts;
-  await client.post<void>(`/rule-groups/${id}/trigger`, undefined, query);
+  await client.post<void>(`/rule-groups/${id}/trigger`, {}, query);
   return { triggered: true, id };
 }
 
@@ -150,7 +150,7 @@ export async function triggerRule(
   if (params.start) query.start = params.start;
   if (params.end) query.end = params.end;
   if (params.accounts?.length) query['accounts[]'] = params.accounts;
-  await client.post<void>(`/rules/${id}/trigger`, undefined, query);
+  await client.post<void>(`/rules/${id}/trigger`, {}, query);
   return { triggered: true, id };
 }
 


### PR DESCRIPTION
## Summary

`trigger_rule` and `trigger_rule_group` failed with **HTTP 415 Unsupported Media Type**. They issued the POST with an `undefined` body, so the client never set the `Content-Type: application/json` header, and Firefly III rejects a bodyless, content-type-less POST with 415.

This passes an empty `{}` body instead. Trigger parameters (`start` / `end` / `accounts[]`) are read from the query string, so an empty body is harmless. It also makes the two tools consistent with the other parameterless POST tools (`trigger_recurrence`, currency `enable` / `disable` / `primary`), which already pass `{}`.

## Changes

- `src/tools/rules.ts`: pass `{}` instead of `undefined` for both trigger POSTs.
- `src/tests/client.test.ts`: regression test — a `{}` body must set `Content-Type: application/json` and serialize `body: "{}"`.
- `src/tests/rules.test.ts`: update the trigger tool assertions.
- `CHANGELOG.md`: add an entry under `[Unreleased]`.
- `.gitignore`: ignore the local `docker-compose.override.yml` Compose override.

## Testing

- `npm test` — all unit tests pass, including the new regression test.
- `tsc --noEmit` — clean.
- Verified end-to-end against a live Firefly III 6.6.3 instance: both tools now return `{ triggered: true, id }` instead of HTTP 415.
