### PR TITLE
fix(http): sweep abandoned OAuth flows on a timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Abandoned OAuth flows are now swept out of memory every 10 minutes instead of only when new authorize/callback traffic arrives. Lazy eviction already kept the map trimmed on a busy server, so this is about an idle one: a server that sees a burst of abandoned authorizations and then goes quiet used to hold those pending `redirect_uri` values indefinitely.
 - Match Dependabot security alerts using both bare and equals-prefixed versions, check all grouped dependencies and alert pages, and distinguish API failures from unmatched advisories.
 - Distinguish back-merge conflicts from other Git failures and retry rejected pushes only when `develop` actually moved. Allow manually retrying the back-merge workflow.
 - `create_account` and `update_account` were missing `liability_type` and `liability_direction`, which the Firefly III API requires when `type` is `liability`. Creating or updating a debt/loan/mortgage account failed with a validation error and no way to supply the required fields. Both are now accepted as optional enums on both tools. _Contributed by [@lesha198a](https://github.com/lesha198a) in [#77](https://github.com/daften/fireflyiii-mcp/pull/77)._

--- a/src/http.ts
+++ b/src/http.ts
@@ -123,6 +123,11 @@ export function createOAuthHandler(
     }
   }
 
+  // Lazy eviction above only runs on authorize/callback traffic, so flows abandoned mid-auth
+  // would otherwise sit in memory indefinitely on a quiet long-running server. unref() keeps
+  // the timer from holding the process open.
+  setInterval(evictExpiredFlows, FLOW_TTL_MS).unref();
+
   return async (req, res) => {
     // Liveness probe — no auth, mode-agnostic. Always 200 whether OAuth is
     // enabled or not, so container/orchestrator health checks don't depend on

--- a/src/http.ts
+++ b/src/http.ts
@@ -125,8 +125,9 @@ export function createOAuthHandler(
 
   // Lazy eviction above only runs on authorize/callback traffic, so flows abandoned mid-auth
   // would otherwise sit in memory indefinitely on a quiet long-running server. unref() keeps
-  // the timer from holding the process open.
-  setInterval(evictExpiredFlows, FLOW_TTL_MS).unref();
+  // the timer from holding the process open. Skipped in PAT-only mode, where /oauth/authorize
+  // 404s and pendingFlows therefore stays empty for the life of the process.
+  if (oauthClientId) setInterval(evictExpiredFlows, FLOW_TTL_MS).unref();
 
   return async (req, res) => {
     // Liveness probe — no auth, mode-agnostic. Always 200 whether OAuth is

--- a/src/tests/http.test.ts
+++ b/src/tests/http.test.ts
@@ -908,6 +908,10 @@ describe('createOAuthHandler — concurrent OAuth flows (P0-1)', () => {
     await handler(callbackReq as http.IncomingMessage, callbackRes as unknown as http.ServerResponse);
 
     expect(callbackRes.statusCode).toBe(400);
+    // Distinguishes the expired-entry branch from the no-entry one. Both say "Start authorization",
+    // and Date.now is mocked rather than the clock advanced, so the sweep never runs and the entry
+    // is still present — this is the only test that reaches `isExpired`.
+    expect(callbackRes.body).toContain('OAuth flow expired');
   });
 });
 

--- a/src/tests/http.test.ts
+++ b/src/tests/http.test.ts
@@ -486,43 +486,14 @@ describe('createOAuthHandler — pending flow expiry', () => {
     vi.useRealTimers();
   });
 
-  it('rejects a callback for a flow older than the 10-minute TTL', async () => {
-    vi.useFakeTimers();
-    const mcpHandler = vi.fn();
-    const handler = createOAuthHandler(
-      'https://firefly.example.com',
-      'client-id-123',
-      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
-    );
-
-    const authReq = mockReq('GET', '/oauth/authorize?redirect_uri=http%3A%2F%2F127.0.0.1%3A9999%2Fcallback&state=old', {
-      host: '127.0.0.1:3000',
-    });
-    await handler(authReq as http.IncomingMessage, mockRes() as unknown as http.ServerResponse);
-
-    // Just past the TTL — also fires the background sweep, which evicts the entry.
-    await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1);
-
-    const cbReq = mockReq('GET', '/oauth/callback?code=abc&state=old', { host: '127.0.0.1:3000' });
-    const cbRes = mockRes();
-    await handler(cbReq as http.IncomingMessage, cbRes as unknown as http.ServerResponse);
-
-    expect(cbRes.statusCode).toBe(400);
-    expect(cbRes.body).toContain('Start authorization');
-  });
-
   it('background sweep evicts abandoned flows without any further traffic', async () => {
     vi.useFakeTimers();
-    const setIntervalSpy = vi.spyOn(global, 'setInterval');
     const mcpHandler = vi.fn();
     const handler = createOAuthHandler(
       'https://firefly.example.com',
       'client-id-123',
       mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
     );
-
-    // The handler registers a periodic sweep so abandoned flows don't accumulate.
-    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 10 * 60 * 1000);
 
     const authReq = mockReq(
       'GET',

--- a/src/tests/http.test.ts
+++ b/src/tests/http.test.ts
@@ -481,6 +481,69 @@ describe('createOAuthHandler — OAuth callback proxy', () => {
   });
 });
 
+describe('createOAuthHandler — pending flow expiry', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects a callback for a flow older than the 10-minute TTL', async () => {
+    vi.useFakeTimers();
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      'client-id-123',
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const authReq = mockReq('GET', '/oauth/authorize?redirect_uri=http%3A%2F%2F127.0.0.1%3A9999%2Fcallback&state=old', {
+      host: '127.0.0.1:3000',
+    });
+    await handler(authReq as http.IncomingMessage, mockRes() as unknown as http.ServerResponse);
+
+    // Just past the TTL — also fires the background sweep, which evicts the entry.
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1);
+
+    const cbReq = mockReq('GET', '/oauth/callback?code=abc&state=old', { host: '127.0.0.1:3000' });
+    const cbRes = mockRes();
+    await handler(cbReq as http.IncomingMessage, cbRes as unknown as http.ServerResponse);
+
+    expect(cbRes.statusCode).toBe(400);
+    expect(cbRes.body).toContain('Start authorization');
+  });
+
+  it('background sweep evicts abandoned flows without any further traffic', async () => {
+    vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(global, 'setInterval');
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      'client-id-123',
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    // The handler registers a periodic sweep so abandoned flows don't accumulate.
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 10 * 60 * 1000);
+
+    const authReq = mockReq(
+      'GET',
+      '/oauth/authorize?redirect_uri=http%3A%2F%2F127.0.0.1%3A9999%2Fcallback&state=abandoned',
+      { host: '127.0.0.1:3000' },
+    );
+    await handler(authReq as http.IncomingMessage, mockRes() as unknown as http.ServerResponse);
+
+    // Two sweep intervals pass with no requests; the second sweep sees the entry as expired.
+    await vi.advanceTimersByTimeAsync(2 * 10 * 60 * 1000 + 1);
+
+    const cbReq = mockReq('GET', '/oauth/callback?code=abc&state=abandoned', { host: '127.0.0.1:3000' });
+    const cbRes = mockRes();
+    await handler(cbReq as http.IncomingMessage, cbRes as unknown as http.ServerResponse);
+
+    // The sweep already removed the entry, so this reads as "no pending flow", not "expired".
+    expect(cbRes.statusCode).toBe(400);
+    expect(cbRes.body).toContain('No pending OAuth flow');
+  });
+});
+
 describe('createOAuthHandler — Bearer guard', () => {
   it('returns 401 with WWW-Authenticate when Authorization header is missing', async () => {
     const mcpHandler = vi.fn();


### PR DESCRIPTION
## Summary

Sweeps abandoned OAuth flows out of memory on a timer instead of only when new authorize/callback traffic arrives.

**Rebased onto `develop` and retargeted.** This PR originally targeted `main` because it predates the branching model that reserves `main` for releases and security fixes. Three months of drift also made most of the original branch obsolete, so the rebase dropped two of its three parts — details below.

## What's left

`src/http.ts` — one line, plus the comment explaining it:

```ts
if (oauthClientId) setInterval(evictExpiredFlows, FLOW_TTL_MS).unref();
```

Lazy eviction already keeps `pendingFlows` trimmed on a busy server, so this is about an idle one: a server that sees a burst of abandoned authorizations and then goes quiet used to hold those pending `redirect_uri` values indefinitely. `unref()` keeps the timer from holding the process open, and it is skipped in PAT-only mode where the whole OAuth surface 404s and the map can never fill.

## What the rebase dropped, and why

**The `.env.example` and `docs/reference/env-vars.md` changes.** That documentation shipped independently in 0.2.1, two days after this PR was opened. The version here predates both PAT-only mode and Claude's always-allowed hosted callbacks, so applying it would have *regressed* the docs on three separate rows — including a now-false claim that only loopback redirect URIs are accepted by default.

**The `CHANGELOG.md` changes.** The branch's snapshot predates several releases, so replaying it spliced three stale bullets into the shipped `## [0.2.1] - 2026-06-11` section, one of them a credit-stripped duplicate of an entry already there. The changelog is taken from `develop` and the new entry filed under `[Unreleased]` instead.

## Review follow-ups (second and third commits)

- **Dropped the duplicate TTL test.** It was named for the TTL path but could no longer reach it: it advanced fake timers past the 10-minute mark, which now fires the sweep first, so the entry was already gone and it exercised the `!entry` branch instead of `isExpired` — its own comment said as much. Its assertion could not tell the two apart either, matching `"Start authorization"`, which both messages contain.
- **Strengthened the surviving TTL test** (`src/tests/http.test.ts:850`) to assert `"OAuth flow expired"`. It mocks `Date.now` rather than advancing the clock, so the sweep never runs and the entry is still present — it is the only test that actually reaches `isExpired`, and it previously asserted the 400 but not the message.
- **Dropped the `expect(setIntervalSpy).toHaveBeenCalledWith(...)` assertion.** It pinned an implementation detail; the rest of that test already proves the sweep behaviourally by advancing past two intervals and observing the entry gone.

**Left alone deliberately:** `createOAuthHandler` still returns only the request handler, so the interval cannot be cancelled. Production calls it once at startup (`src/http.ts:382`), and every handler the tests build closes over its own empty map, so widening the return type and threading a disposer through `index.ts` and every test costs more than it buys.

## Type of change

- [x] fix (bug fix)

## Checklist

- [x] Tests added or updated
- [x] `npm test` passes locally — 448 passed, 17 skipped
- [x] `npx tsc --noEmit` passes locally
- [x] `npx biome check src/` passes locally
- [ ] README tool table updated — n/a
- [ ] CLAUDE.md updated — n/a
- [ ] Verified against the Firefly III OpenAPI spec — n/a, OAuth proxy only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7kJ7nuRfXnhxyn6eLHECY
