### PR TITLE
docs: add architecture overview, Node requirement note, CSV mime hint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,39 @@ Users can query their finances in natural language through Claude, getting answe
 
 **Current state:** 140 tools across 14 groups, full CRUD, stdio and HTTP/OAuth transports, tool filtering via `--preset`/`--groups`/`--read-only`.
 
+### Architecture at a glance
+
+```
+MCP client (Claude Code / Desktop / ...)
+        │
+        │  stdio                          HTTP (StreamableHTTP, stateless)
+        ▼                                 ▼
+  StdioServerTransport          OAuth proxy (src/http.ts)
+        │                         · /.well-known metadata, /oauth/{authorize,token,register,callback}
+        │                         · substitutes redirect_uri, Bearer guard
+        │                         · per-request token via AsyncLocalStorage
+        └────────────┬────────────┘
+                     ▼
+            McpServer (src/server.ts)
+                     │  registerAllTools (src/tools/index.ts)
+                     │  · TOOL_GROUPS / PRESETS filtering, read-only proxy
+                     ▼
+      Tool groups (src/tools/*.ts, 14 groups / 140 tools)
+        · defineTool wrapper: zod validation, error formatting (src/tools/_helpers.ts)
+        · autocomplete prompts with per-user TTL cache
+                     │
+                     ▼
+        FireflyClient (src/client.ts)
+        · Bearer auth, 30s timeout, FireflyError → friendly messages
+                     │
+                     ▼
+        Transform layer (src/transform.ts)
+        · unwraps JSON:API envelopes → flat objects + pagination
+                     │
+                     ▼
+            Firefly III REST API (/api/v1)
+```
+
 ---
 
 ## Tech Stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+- New "Architecture at a glance" diagram in AGENTS.md showing the path from MCP client through transports, tool registration, the HTTP client, and the transform layer to the Firefly III API.
+- README now states the Node.js 20+ requirement next to the setup options table.
+- Export tool descriptions mention the `text/csv` output format.
+
 ## [0.2.0] - 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Choose your setup method:
 | [Docker — HTTP](#option-3-docker--http-self-hosted) | HTTP + OAuth | Self-hosted on a server or home lab |
 | [Git checkout](#option-4-git-checkout-development) | stdio or HTTP | Contributing or local development |
 
+All options except Docker require **Node.js 20+**.
+
 ---
 
 ## Option 1: npm package — stdio (simplest)

--- a/src/tools/exports.ts
+++ b/src/tools/exports.ts
@@ -52,7 +52,7 @@ export function registerExportTools(server: McpServer, client: FireflyClient): v
       name,
       {
         title,
-        description: `Export all ${entity} as a CSV file. Returns raw CSV text.${hasDates ? ' Optionally filter by date range.' : ''}`,
+        description: `Export all ${entity} as a CSV file. Returns raw CSV text (text/csv).${hasDates ? ' Optionally filter by date range.' : ''}`,
         inputSchema,
         annotations: READ_ANNOTATIONS,
       },


### PR DESCRIPTION
## Summary

Documentation polish, no behavior change:

- **AGENTS.md** gains an "Architecture at a glance" ASCII diagram showing the path from MCP client through both transports (stdio and HTTP with the OAuth proxy), tool registration/filtering, the `defineTool` wrapper, the HTTP client, and the transform layer down to the Firefly III API.
- **README** now states the Node.js 20+ requirement next to the setup options table, instead of only inside Option 1 (it applies to every non-Docker option).
- **Export tool descriptions** now mention `text/csv` so MCP clients know the output format of the `export_*` tools.

> Note: this PR and #23 both touch `src/tools/exports.ts` (this one edits the description string, #23 restructures the function). Whichever merges second will need a small mechanical conflict resolution there, plus the usual `CHANGELOG.md` `[Unreleased]` merge conflict shared by all four open PRs.

## Type of change

- [ ] feat (new tool or feature)
- [ ] fix (bug fix)
- [ ] refactor (code cleanup, no behavior change)
- [ ] test (add or update tests)
- [ ] chore (dependencies, config, scaffolding)
- [x] docs (documentation only)

## Checklist

- [ ] Tests added or updated *(N/A — docs and description strings only)*
- [x] `npm test` passes locally
- [x] `npx tsc --noEmit` passes locally
- [ ] README tool table updated (if a new tool was added) *(N/A)*
- [x] CLAUDE.md updated (if architectural) *(AGENTS.md — the documentation source of truth — gained the architecture overview)*
- [ ] Verified relevant fields against the [Firefly III OpenAPI spec](https://api-docs.firefly-iii.org/) (if API-touching) *(N/A)*

https://claude.ai/code/session_01Ki7GA1ohdzUZz3GsRfAC2t