### PR TITLE
ci: nightly release builds (npm/docker/github)

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -165,6 +165,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: nightly
+          target_commitish: ${{ github.sha }}
           name: "Nightly ${{ needs.verify.outputs.version }}"
           prerelease: true
           make_latest: false

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,179 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # 03:00 UTC, after the 02:00 integration tests
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Publish even if main has not changed since the last nightly'
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine whether main changed since last nightly
+        id: check
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            echo "force=true requested; publishing."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git rev-parse -q --verify refs/tags/nightly >/dev/null; then
+            LAST_SHA=$(git rev-list -n 1 nightly)
+          else
+            LAST_SHA=""
+          fi
+          echo "HEAD=$HEAD_SHA  last_nightly=${LAST_SHA:-<none>}"
+          if [ -n "$LAST_SHA" ] && [ "$HEAD_SHA" = "$LAST_SHA" ]; then
+            echo "main unchanged since last nightly; skipping publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "main changed (or no prior nightly); will publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  verify:
+    needs: guard
+    if: needs.guard.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: for i in 1 2 3; do npm ci && break || sleep 5; done
+
+      - name: Lint (Biome)
+        run: npx biome ci src/
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npm test
+
+      - name: Compute nightly version
+        id: version
+        run: |
+          NEXT=$(node -p "const [a,b,c]=require('./package.json').version.split('.').map(Number); [a,b,c+1].join('.')")
+          STAMP=$(date -u +%Y%m%dT%H%M)
+          VERSION="${NEXT}-nightly.${STAMP}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Nightly version: $VERSION"
+
+  publish-npm:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Set nightly version (in-CI only, not committed)
+        run: npm version "${{ needs.verify.outputs.version }}" --no-git-tag-version
+
+      - name: Publish nightly to npm (nightly dist-tag, never latest)
+        run: npm publish --provenance --tag nightly
+
+  publish-docker:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker tags + labels (nightly only, never latest)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/daften/fireflyiii-mcp
+          tags: |
+            type=raw,value=nightly
+            type=raw,value=nightly-{{date 'YYYYMMDD'}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  release:
+    needs: [verify, publish-npm, publish-docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Move rolling nightly tag to HEAD
+        run: |
+          git tag -f nightly
+          git push -f origin refs/tags/nightly
+
+      - name: Create/update nightly pre-release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: nightly
+          name: "Nightly ${{ needs.verify.outputs.version }}"
+          prerelease: true
+          make_latest: false
+          body: |
+            Automated nightly build of `main`. **Unstable — for testing unreleased changes.**
+
+            - Version: `${{ needs.verify.outputs.version }}`
+            - Commit: ${{ github.sha }}
+            - npm: `npm install @daften/fireflyiii-mcp@nightly`
+            - Docker: `docker pull ghcr.io/daften/fireflyiii-mcp:nightly`
+
+            > Default installs (`@latest` / `:latest`) are unaffected and continue to point at the most recent tagged release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,6 +466,18 @@ expect(result).toEqual({ name: 'Checking', current_balance: '1000', id: '1' });
 4. Create an annotated git tag whose message is the same `## [X.Y.Z]` block from `CHANGELOG.md`. The publish workflow validates that this section exists before publishing.
 5. Push the tag: `git push origin v<version>` — this triggers the publish workflow, which validates the changelog, runs tests, publishes to npm + GHCR, and auto-creates a GitHub Release from the tag annotation.
 
+### Nightly builds
+
+`.github/workflows/nightly-release.yml` runs on a cron (`0 3 * * *` UTC) and on manual `workflow_dispatch` (with an optional `force` input). A `guard` job publishes only when `main`'s HEAD differs from the commit the rolling `nightly` git tag points at, so it builds only on nights `main` changed.
+
+When it publishes it:
+- runs lint/typecheck/tests, then computes a prerelease version `<next-patch>-nightly.<UTCstamp>` (in-CI only, never committed);
+- publishes to npm under the **`nightly`** dist-tag (`npm publish --tag nightly`) — the `latest` dist-tag is never touched;
+- pushes Docker tags `:nightly` and `:nightly-YYYYMMDD` to `ghcr.io` — `:latest` is never touched;
+- force-moves the `nightly` git tag to HEAD and updates a GitHub pre-release (`prerelease: true`, `make_latest: false`).
+
+This is independent of `publish.yml` (tagged releases) and of `nightly.yml` (Firefly III integration tests).
+
 ---
 
 ## Commits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Nightly release workflow (`.github/workflows/nightly-release.yml`): on nights `main` changes, publishes an unstable prerelease to npm (`nightly` dist-tag), Docker (`ghcr.io/daften/fireflyiii-mcp:nightly`), and a GitHub pre-release. Default installs (`@latest` / `:latest`) are never affected. Install unreleased changes via `@daften/fireflyiii-mcp@nightly`.
+
 ### Security
 - Upgraded the docs toolchain from `vitepress@1.6.4` to `vitepress@2.0.0-alpha.17`, which moves the docs build onto Vite 7. This resolves two Dependabot alerts in `devDependencies`: a path-traversal in Vite's optimized-deps `.map` handling (`vite ≤6.4.1`) and an esbuild dev-server request issue (`esbuild ≤0.24.2`). vitepress 2 is still pre-release but is required to reach a Vite version compatible with the patched esbuild; the version is pinned exactly and the docs build is verified.
 - Pinned `esbuild` to `^0.28.1` across the whole `devDependencies` tree via an `overrides` entry, closing the remaining two Dependabot alerts: a high-severity binary-integrity / RCE-via-`NPM_CONFIG_REGISTRY` issue (`esbuild <0.28.1`) and a Windows dev-server file-read issue (`esbuild ≥0.27.3 <0.28.1`). `npm audit` now reports 0 vulnerabilities. The override only takes effect once on Vite 7 (above), since esbuild 0.28.1 is incompatible with the Vite 5 that vitepress 1.x used.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ Your MCP client downloads and starts the server automatically on first use. No s
 
 ---
 
+## Nightly builds (unstable)
+
+Want to test unreleased changes from `main`? A nightly build is published automatically each night that `main` has changed. **These are unstable and not recommended for production.**
+
+- **npm:** `npm install @daften/fireflyiii-mcp@nightly` (or `npx @daften/fireflyiii-mcp@nightly`)
+- **Docker:** `docker pull ghcr.io/daften/fireflyiii-mcp:nightly`
+
+A normal install (no tag) always resolves to the latest tagged release — `@latest` on npm and `:latest` on Docker are never moved to a nightly. To go back to a stable build, reinstall without the `@nightly` / `:nightly` tag.
+
+---
+
 ## Experimental Autocomplete Prompts
 
 → See [Autocomplete prompts](https://daften.github.io/fireflyiii-mcp/reference/autocomplete) in the docs.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   description:
     'Connect any MCP-compatible AI assistant to your Firefly III personal finance instance.',
   base: '/fireflyiii-mcp/',
-  srcExclude: ['design/**'],
+  srcExclude: ['design/**', 'superpowers/**'],
   themeConfig: {
     nav: [
       { text: 'Guide', link: '/guide/' },
@@ -23,6 +23,7 @@ export default defineConfig({
             { text: 'npm + HTTP/OAuth', link: '/guide/http-oauth' },
             { text: 'Docker + HTTP', link: '/guide/docker' },
             { text: 'Git checkout', link: '/guide/git-checkout' },
+            { text: 'Nightly builds', link: '/guide/nightly' },
           ],
         },
       ],

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -19,6 +19,10 @@
 
 **Not sure which to pick?** Start with [npm — stdio](./stdio) — it's one config block and requires no server setup.
 
+## Nightly builds
+
+Want to test unreleased changes from `main`? Install a [nightly build](./nightly) via the `@nightly` (npm) or `:nightly` (Docker) tag. Nightlies are unstable — a normal install always gives you the latest tagged release.
+
 ## How it works
 
 The server exposes Firefly III's REST API as MCP tools. Your AI assistant calls these tools automatically when you ask finance-related questions. You never write API calls manually.

--- a/docs/guide/nightly.md
+++ b/docs/guide/nightly.md
@@ -1,0 +1,52 @@
+# Nightly builds (unstable)
+
+Nightly builds let you try unreleased changes from `main` before they ship in a tagged release. A new nightly is published automatically each night that `main` has changed.
+
+::: warning Unstable
+Nightly builds are not release-tested and may contain breaking or incomplete changes. Don't use them in production. For stable use, install the default (tagged) release instead.
+:::
+
+## Install
+
+### npm
+
+```json
+{
+  "mcpServers": {
+    "fireflyiii": {
+      "command": "npx",
+      "args": ["-y", "@daften/fireflyiii-mcp@nightly"],
+      "env": {
+        "FIREFLY_URL": "https://your-firefly-instance.example.com",
+        "FIREFLY_TOKEN": "your-personal-access-token-here"
+      }
+    }
+  }
+}
+```
+
+The `@nightly` tag is what pins you to the nightly channel. Drop it to return to the latest tagged release.
+
+### Docker
+
+```bash
+docker pull ghcr.io/daften/fireflyiii-mcp:nightly
+```
+
+## How nightlies are versioned
+
+Each nightly is published as a SemVer pre-release, for example `0.2.2-nightly.20260614T0300`. Because it is a pre-release:
+
+- A normal install with no tag always resolves to the latest **tagged** release — never a nightly. On npm the `latest` dist-tag is never moved to a nightly; on Docker the `:latest` tag is never moved either.
+- Version-range installs (for example `^0.2.1`) also skip nightlies, because npm excludes pre-releases from ranges unless you explicitly opt in.
+
+You only ever receive a nightly by explicitly requesting the `@nightly` (npm) or `:nightly` (Docker) tag.
+
+## Going back to a stable build
+
+Reinstall without the nightly tag:
+
+```bash
+npx -y @daften/fireflyiii-mcp          # latest tagged release
+docker pull ghcr.io/daften/fireflyiii-mcp:latest
+```


### PR DESCRIPTION
## Summary

Adds an automated **nightly release** that publishes unreleased `main` so it can be installed and tested before a tagged release — while guaranteeing default installs never resolve to a nightly.

- New workflow `.github/workflows/nightly-release.yml`: cron `0 3 * * *` (+ manual `workflow_dispatch` with a `force` input). A `guard` job publishes only on nights `main` actually changed, using a rolling `nightly` git tag as the last-built marker.
- Publishes to three channels, each isolated from `latest`:
  - **npm** under the `nightly` dist-tag (`npm publish --tag nightly`) — `latest` is never moved.
  - **Docker** `ghcr.io/daften/fireflyiii-mcp:nightly` + `:nightly-YYYYMMDD` — `:latest` is never moved.
  - **GitHub** pre-release on the rolling `nightly` tag (`prerelease: true`, `make_latest: false`, pinned to HEAD via `target_commitish`).
- Versioning: `<next-patch>-nightly.<UTCstamp>` (e.g. `0.2.2-nightly.20260614T0300`), computed in-CI only, never committed. As a SemVer pre-release it's also excluded from range installs like `^0.2.1`.
- Build gate mirrors CI: lint + typecheck + unit tests before publishing. Independent of the existing `nightly.yml` (Firefly integration tests) and `publish.yml` (tagged releases).
- Docs: README "Nightly builds" section, AGENTS.md subsection, CHANGELOG entry, and a new `/guide/nightly` page on the docs site (sidebar + overview cross-link).

## ⚠️ Required before the first npm nightly can publish

npm trusted publishing is keyed to a specific workflow filename. `publish.yml` publishes via OIDC with no token; this new workflow file must be authorized the same way. **Before merging is fine, but before the first nightly run:** add `nightly-release.yml` as a trusted publisher for `@daften/fireflyiii-mcp` on npmjs.com, **or** add an `NPM_TOKEN` secret + `NODE_AUTH_TOKEN` env to the `publish-npm` step. Docker (GHCR) and the GitHub pre-release use the built-in `GITHUB_TOKEN` and need no setup.

## Test Plan

- [x] `actionlint` clean (only the pre-existing `npm ci` retry shellcheck warnings shared with `ci.yml`)
- [x] `npm test` passes (392 passed)
- [x] `npm run docs:build` succeeds, nightly page renders, no dead links
- [ ] After merge: `gh workflow run "Nightly Release" --ref main -f force=true` → all jobs green
- [ ] Verify `npm dist-tag ls` shows `nightly` set and `latest` unchanged; `^0.2.1` range install does not pick the nightly
- [ ] Verify Docker `:nightly` exists and `:latest` unchanged; GitHub "Latest release" still points at the last `v*` tag
- [ ] Dispatch again without `force` → `guard` outputs `should_publish=false`, publish jobs skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)