### PR TITLE
Support PAT-only HTTP mode without FIREFLY_OAUTH_CLIENT_ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,14 +4,21 @@ FIREFLY_URL=https://your-firefly-instance.example.com
 # Required for stdio transport (default)
 FIREFLY_TOKEN=your-personal-access-token-here
 
-# Required for HTTP transport (--transport http)
-# Create a public OAuth client in Firefly III: Profile → OAuth → OAuth Clients → Create New Client
+# Optional for HTTP transport (--transport http).
+# Set this to enable OAuth: create a public OAuth client in Firefly III —
+# Profile → OAuth → OAuth Clients → Create New Client.
 # Mark as "Public client" (no secret required — uses PKCE).
 # Copy the Client ID here:
 # FIREFLY_OAUTH_CLIENT_ID=your-oauth-client-id-here
+#
+# Omit FIREFLY_OAUTH_CLIENT_ID entirely to run HTTP transport in PAT-only mode
+# instead: no OAuth proxy is exposed, and every request authenticates with a
+# Firefly III Personal Access Token sent as a Bearer token. See the HTTP/PAT
+# guide for headless callers (gateways, automation) that can't open a browser.
 
 # Required for HTTP transport when not on loopback (e.g. Docker, reverse proxy)
-# Public base URL of THIS MCP server — used to construct OAuth redirect URIs.
+# AND FIREFLY_OAUTH_CLIENT_ID is set — used to construct OAuth redirect URIs.
+# Not used in PAT-only mode.
 MCP_BASE_URL=https://mcp.example.com
 
 # Optional (both transports): emit verbose autocomplete tracing to stderr.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 Users can query their finances in natural language through Claude, getting answers about accounts, transactions, budgets, categories, bills, piggy banks, and financial insights without writing queries themselves.
 
-**Current state:** 140 tools across 14 groups, full CRUD, stdio and HTTP/OAuth transports, tool filtering via `--preset`/`--groups`/`--read-only`.
+**Current state:** 140 tools across 14 groups, full CRUD, stdio and HTTP (OAuth or PAT) transports, tool filtering via `--preset`/`--groups`/`--read-only`.
 
 ### Architecture at a glance
 
@@ -17,6 +17,7 @@ MCP client (Claude Code / Desktop / ...)
         ▼                                 ▼
   StdioServerTransport          OAuth proxy (src/http.ts)
         │                         · /.well-known metadata, /oauth/{authorize,token,register,callback}
+        │                           (404 instead, if FIREFLY_OAUTH_CLIENT_ID is unset — PAT-only mode)
         │                         · substitutes redirect_uri, Bearer guard
         │                         · per-request token via AsyncLocalStorage
         └────────────┬────────────┘
@@ -66,11 +67,12 @@ FIREFLY_TOKEN     String, required. Personal Access Token from Firefly III Optio
 **HTTP transport:**
 ```
 FIREFLY_URL                String, required. Base URL of Firefly III instance (no trailing slash).
-FIREFLY_OAUTH_CLIENT_ID    String, required. OAuth client ID from Firefly III Options → Remote access and tokens → Create New Client.
-MCP_BASE_URL               String, required when not listening on loopback. Public base URL of this server.
+FIREFLY_OAUTH_CLIENT_ID    String, optional. OAuth client ID from Firefly III Options → Remote access and tokens → Create New Client.
+                           Omit to run in PAT-only mode (no OAuth proxy surface; see below).
+MCP_BASE_URL               String, required when not listening on loopback AND FIREFLY_OAUTH_CLIENT_ID is set. Public base URL of this server.
 ```
 
-In HTTP mode, the Bearer token is resolved per-request from the Authorization header (set by the MCP client after completing the OAuth flow). `FIREFLY_TOKEN` is not used in HTTP mode.
+In HTTP mode, the Bearer token is always resolved per-request from the Authorization header — either set by the MCP client after completing the OAuth flow, or supplied directly as a Firefly III Personal Access Token when `FIREFLY_OAUTH_CLIENT_ID` is unset (PAT-only mode). `FIREFLY_TOKEN` is not used in HTTP mode.
 
 **Optional (both transports):**
 ```
@@ -379,6 +381,8 @@ Routes handled by the proxy (no auth required):
 All other requests require a `Bearer` token in the `Authorization` header. The token is propagated via `AsyncLocalStorage` so `FireflyClient` can read it without it being passed through every call chain.
 
 **Limitation:** OAuth state lives in-process — single replica only. Horizontal scaling breaks the auth flow.
+
+**PAT-only mode:** when `FIREFLY_OAUTH_CLIENT_ID` is unset, none of the proxy routes above are registered — each one 404s instead, since there's no real OAuth client behind them. Every request falls straight through to the `Bearer` token check, and whatever token is supplied is forwarded to Firefly III as-is. This is for headless callers (gateways, automation) that hold a Firefly III Personal Access Token and have no way to drive an interactive browser-based OAuth flow.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - HTTP transport now supports PAT-only mode: `FIREFLY_OAUTH_CLIENT_ID` is optional, and omitting it runs the server without the OAuth proxy surface (`/.well-known/oauth-authorization-server` and `/oauth/*` now 404), authenticating every request with a Firefly III Personal Access Token sent as a Bearer token instead. `MCP_BASE_URL` is no longer required in this mode, since there's no OAuth redirect URI to construct. Intended for headless callers — gateways, automation — that have no way to drive an interactive browser-based OAuth flow. See the new [HTTP/PAT guide](https://daften.github.io/fireflyiii-mcp/guide/http-pat).
+- Unauthenticated, mode-agnostic `GET /health` liveness endpoint that always returns `200 {"status":"ok"}`. The Docker `HEALTHCHECK` now probes `/health` instead of the OAuth metadata endpoint, so containers report healthy in PAT-only mode (where the OAuth surface 404s).
 
 ### Security
 - Pinned the transitive `hono` dependency (pulled in by `@modelcontextprotocol/sdk`) to `^4.12.25` via an `overrides` entry, closing a high-severity advisory affecting `hono <=4.12.24` (GHSA-wwfh-h76j-fc44 and related). None of the flagged code paths (`serve-static` on Windows, the AWS Lambda / Lambda@Edge adapters, CORS middleware) are reachable from this server, which uses the raw Node `http` module — but the bump clears the `npm audit --audit-level=moderate` gate in CI. `npm audit` now reports 0 vulnerabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- HTTP transport now supports PAT-only mode: `FIREFLY_OAUTH_CLIENT_ID` is optional, and omitting it runs the server without the OAuth proxy surface (`/.well-known/oauth-authorization-server` and `/oauth/*` now 404), authenticating every request with a Firefly III Personal Access Token sent as a Bearer token instead. `MCP_BASE_URL` is no longer required in this mode, since there's no OAuth redirect URI to construct. Intended for headless callers — gateways, automation — that have no way to drive an interactive browser-based OAuth flow. See the new [HTTP/PAT guide](https://daften.github.io/fireflyiii-mcp/guide/http-pat).
+
 ### Security
 - Pinned the transitive `hono` dependency (pulled in by `@modelcontextprotocol/sdk`) to `^4.12.25` via an `overrides` entry, closing a high-severity advisory affecting `hono <=4.12.24` (GHSA-wwfh-h76j-fc44 and related). None of the flagged code paths (`serve-static` on Windows, the AWS Lambda / Lambda@Edge adapters, CORS middleware) are reachable from this server, which uses the raw Node `http` module — but the bump clears the `npm audit --audit-level=moderate` gate in CI. `npm audit` now reports 0 vulnerabilities.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ RUN npm ci --omit=dev --ignore-scripts
 COPY --from=builder /app/dist ./dist
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3000/.well-known/oauth-authorization-server || exit 1
+  CMD wget -qO- http://127.0.0.1:3000/health || exit 1
 CMD ["node", "dist/index.js", "--transport", "http", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Choose your setup method:
 | Method | Transport | Best for |
 |--------|-----------|----------|
 | [npm — stdio](#option-1-npm-package--stdio-simplest) | stdio | Simplest setup, AI on the same machine |
-| [npm — HTTP](#option-2-npm-package--http-oauth) | HTTP + OAuth | Remote AI access or when you prefer OAuth over a PAT |
-| [Docker — HTTP](#option-3-docker--http-self-hosted) | HTTP + OAuth | Self-hosted on a server or home lab |
+| [npm — HTTP](#option-2-npm-package--http-oauth-or-pat) | HTTP + OAuth or PAT | Remote AI access, or a headless gateway with no browser in the loop |
+| [Docker — HTTP](#option-3-docker--http-self-hosted) | HTTP + OAuth or PAT | Self-hosted on a server or home lab |
 | [Git checkout](#option-4-git-checkout-development) | stdio or HTTP | Contributing or local development |
 
 All options except Docker require **Node.js 20+**.
@@ -62,9 +62,9 @@ Your MCP client downloads and starts the server automatically on first use. No s
 
 ---
 
-## Option 2: npm package — HTTP (OAuth)
+## Option 2: npm package — HTTP (OAuth or PAT)
 
-→ See [HTTP/OAuth setup guide](https://daften.github.io/fireflyiii-mcp/guide/http-oauth) in the docs.
+→ See the [HTTP/OAuth](https://daften.github.io/fireflyiii-mcp/guide/http-oauth) setup guide, or [HTTP/PAT](https://daften.github.io/fireflyiii-mcp/guide/http-pat) for headless callers (gateways, automation) that can't drive a browser-based OAuth flow.
 
 ---
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
             { text: 'Overview', link: '/guide/' },
             { text: 'npm + stdio', link: '/guide/stdio' },
             { text: 'npm + HTTP/OAuth', link: '/guide/http-oauth' },
+            { text: 'npm + HTTP/PAT', link: '/guide/http-pat' },
             { text: 'Docker + HTTP', link: '/guide/docker' },
             { text: 'Git checkout', link: '/guide/git-checkout' },
             { text: 'Nightly builds', link: '/guide/nightly' },

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -5,6 +5,10 @@ Docker runs in HTTP mode only. Suitable for hosting on a server or home lab wher
 The container image is published to GitHub Container Registry:
 **[ghcr.io/daften/fireflyiii-mcp](https://github.com/daften/fireflyiii-mcp/pkgs/container/fireflyiii-mcp)**
 
+::: tip Headless caller? Use PAT-only mode instead
+The steps below set up OAuth, which needs a browser and a human to approve it on first connection. If this container is fronted by something that can't do that — a gateway, an automation script — skip straight to [npm + HTTP/PAT](/guide/http-pat) instead: omit `FIREFLY_OAUTH_CLIENT_ID` and `MCP_BASE_URL`, and authenticate with a Bearer-token Personal Access Token instead.
+:::
+
 ## Step 1: Register an OAuth client in Firefly III
 
 Go to **Options → Remote access and tokens → Create New Client**:

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -69,6 +69,10 @@ docker compose up -d
 OAuth state is held in-process. Run only one container replica — multiple replicas will break the OAuth flow because the callback may land on a different instance than the one that initiated authorization.
 :::
 
+### Health check
+
+The image ships a Docker `HEALTHCHECK` that probes `GET /health`, which returns `200 {"status":"ok"}` in both OAuth and PAT-only mode (it requires no authentication). Use the same endpoint for orchestrator liveness/readiness probes (Kubernetes, compose `depends_on: { condition: service_healthy }`, etc.).
+
 ## Step 3: Connect your AI client
 
 ```json

--- a/docs/guide/http-oauth.md
+++ b/docs/guide/http-oauth.md
@@ -4,6 +4,10 @@ HTTP mode uses OAuth 2.0 (Authorization Code + PKCE) instead of a Personal Acces
 
 **Requires:** Node.js 20+.
 
+::: tip Headless caller? Use PAT-only mode instead
+The OAuth flow below needs a browser and a human to approve it on first connection. If you're connecting from somewhere that can't do that — a server-side gateway, an automation script — see [npm + HTTP/PAT](/guide/http-pat), which skips OAuth entirely in favor of a Bearer-token Personal Access Token.
+:::
+
 ## Step 1: Register an OAuth client in Firefly III
 
 Go to **Options → Remote access and tokens → Create New Client**:

--- a/docs/guide/http-pat.md
+++ b/docs/guide/http-pat.md
@@ -1,0 +1,34 @@
+# npm + HTTP/PAT
+
+HTTP mode normally uses OAuth 2.0 (see [npm + HTTP/OAuth](/guide/http-oauth)), which requires an interactive browser-based authorization step. That works well for AI clients running on your own machine, but it has no equivalent for headless callers — a server-side gateway, automation script, or anything else that talks to this server without a human or a browser in the loop.
+
+For those cases, omit `FIREFLY_OAUTH_CLIENT_ID` and the server runs in **PAT-only mode** instead: no OAuth proxy is exposed, and every request just needs a Firefly III Personal Access Token as a Bearer token.
+
+**Requires:** Node.js 20+, a Firefly III Personal Access Token (Options → Remote access and tokens → Create new token).
+
+## Step 1: Start the server
+
+```bash
+FIREFLY_URL=https://your-firefly-instance.example.com \
+npx @daften/fireflyiii-mcp --transport http
+```
+
+No OAuth client registration needed. To use a different port, add `--port 4000`.
+
+## Step 2: Connect your client
+
+Configure your MCP client (or gateway) to call this server over HTTP, sending your Firefly III PAT as a Bearer token on every request:
+
+```
+Authorization: Bearer <your-firefly-iii-personal-access-token>
+```
+
+For example, in a gateway that lets you configure a static bearer token per backend MCP server, point it at `http://127.0.0.1:3000` (or wherever you're hosting this) with that header — no separate client-side OAuth configuration is needed.
+
+::: tip Why does this work?
+The Bearer token on each request is forwarded to Firefly III's API exactly as given — that's true whether it came from an OAuth-issued access token or a PAT, since the server doesn't need to know which. PAT-only mode just stops advertising and serving the OAuth surface (`/.well-known/oauth-authorization-server`, `/oauth/*`), since there's no OAuth client configured to back it.
+:::
+
+::: warning
+PAT-only mode skips the `MCP_BASE_URL` requirement that OAuth mode enforces on non-loopback hosts, since there's no OAuth redirect URI to construct. If you later add `FIREFLY_OAUTH_CLIENT_ID` to also support interactive clients, see [npm + HTTP/OAuth](/guide/http-oauth) for `MCP_BASE_URL` guidance.
+:::

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -14,10 +14,10 @@ Store credentials in a `.env` file (gitignored). Copy `.env.example` from the re
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `FIREFLY_URL` | Yes | Base URL of your Firefly III instance. No trailing slash. |
-| `FIREFLY_OAUTH_CLIENT_ID` | Yes | OAuth client ID from Firefly III Options → Remote access and tokens → Create New Client. |
-| `MCP_BASE_URL` | Required when not on loopback | Public base URL of this server. Used to build OAuth redirect URIs. Required when hosting on a server; omit for local `127.0.0.1` setups. |
+| `FIREFLY_OAUTH_CLIENT_ID` | No | OAuth client ID from Firefly III Options → Remote access and tokens → Create New Client. Omit to run in [PAT-only mode](/guide/http-pat) instead of OAuth. |
+| `MCP_BASE_URL` | Required when not on loopback, and only if `FIREFLY_OAUTH_CLIENT_ID` is set | Public base URL of this server. Used to build OAuth redirect URIs. Not used in PAT-only mode. |
 
-In HTTP mode, `FIREFLY_TOKEN` is not used. The Bearer token is resolved per-request from the `Authorization` header after the OAuth flow.
+In HTTP mode, `FIREFLY_TOKEN` is not used. The Bearer token is resolved per-request from the `Authorization` header instead — either set by the MCP client after completing the OAuth flow, or supplied directly as your Firefly III Personal Access Token when `FIREFLY_OAUTH_CLIENT_ID` is omitted. See [npm + HTTP/OAuth](/guide/http-oauth) and [npm + HTTP/PAT](/guide/http-pat).
 
 ## Tool filtering (both transports)
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -60,6 +60,15 @@ export function createOAuthHandler(
   }
 
   return async (req, res) => {
+    // Liveness probe — no auth, mode-agnostic. Always 200 whether OAuth is
+    // enabled or not, so container/orchestrator health checks don't depend on
+    // the OAuth surface (which 404s in PAT-only mode).
+    if ((req.method === 'GET' || req.method === 'HEAD') && req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(req.method === 'HEAD' ? undefined : JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
     const baseUrl =
       (process.env.MCP_BASE_URL?.trim().replace(/\/$/, '') || null) ?? `http://${req.headers.host ?? '127.0.0.1:3000'}`;
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -32,9 +32,21 @@ function isRedirectUriAllowed(uri: string): boolean {
     .some((p) => p && uri.startsWith(p));
 }
 
+// Mirrors the route matching used by the branches below — kept in sync so that
+// disabling OAuth (no client ID) cleanly 404s the same surface it would otherwise serve.
+function isOAuthProxyPath(url: string): boolean {
+  return (
+    url === '/.well-known/oauth-authorization-server' ||
+    url.startsWith('/oauth/authorize') ||
+    url === '/oauth/register' ||
+    url === '/oauth/token' ||
+    url.startsWith('/oauth/callback')
+  );
+}
+
 export function createOAuthHandler(
   fireflyUrl: string,
-  oauthClientId: string,
+  oauthClientId: string | undefined,
   mcpHandler: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
 ): (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void> {
   const FLOW_TTL_MS = 10 * 60 * 1000;
@@ -50,6 +62,20 @@ export function createOAuthHandler(
   return async (req, res) => {
     const baseUrl =
       (process.env.MCP_BASE_URL?.trim().replace(/\/$/, '') || null) ?? `http://${req.headers.host ?? '127.0.0.1:3000'}`;
+
+    // PAT-only mode (no FIREFLY_OAUTH_CLIENT_ID): the OAuth proxy surface isn't
+    // backed by a real client, so report it as absent rather than serving a
+    // half-working flow. Clients fall back to a manually configured Bearer token.
+    if (!oauthClientId && req.url && isOAuthProxyPath(req.url)) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'not_found',
+          error_description: 'OAuth is not enabled on this server. Authenticate with a Bearer token instead.',
+        }),
+      );
+      return;
+    }
 
     if (req.method === 'GET' && req.url === '/.well-known/oauth-authorization-server') {
       const metadata = {
@@ -230,11 +256,13 @@ export async function startHttpServer(
   host: string,
   requestedPort: number,
   portWasExplicit: boolean,
-  oauthClientId: string,
+  oauthClientId: string | undefined,
   fireflyUrl: string,
   tryListenFn: (server: http.Server, host: string, port: number) => Promise<void> = tryListen,
 ): Promise<void> {
-  if (!process.env.MCP_BASE_URL?.trim()) {
+  // MCP_BASE_URL only matters for constructing OAuth redirect URIs — irrelevant
+  // in PAT-only mode (no oauthClientId), since no OAuth surface is served.
+  if (oauthClientId && !process.env.MCP_BASE_URL?.trim()) {
     if (classifyHost(host) === 'non-loopback') {
       process.stderr.write(
         `Error: MCP_BASE_URL must be set when binding to a non-loopback interface (--host ${host}).\n` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,13 @@ const { transport, host, port, portWasExplicit, filterOptions } = parsed;
 const url = process.env.FIREFLY_URL;
 
 if (transport === 'http') {
+  // FIREFLY_OAUTH_CLIENT_ID is optional: when unset, the server runs in PAT-only
+  // mode (no OAuth proxy surface) and expects a Firefly III Personal Access Token
+  // as the per-request Bearer token instead.
   const oauthClientId = process.env.FIREFLY_OAUTH_CLIENT_ID;
-  if (!url || !oauthClientId) {
+  if (!url) {
     process.stderr.write(
-      'Error: FIREFLY_URL and FIREFLY_OAUTH_CLIENT_ID environment variables are required for HTTP transport.\n' +
+      'Error: FIREFLY_URL environment variable is required for HTTP transport.\n' +
         'See .env.example for configuration instructions.\n',
     );
     process.exit(1);

--- a/src/tests/http.test.ts
+++ b/src/tests/http.test.ts
@@ -512,6 +512,176 @@ describe('createOAuthHandler — Bearer guard', () => {
   });
 });
 
+describe('createOAuthHandler — PAT-only mode (no oauthClientId)', () => {
+  it('returns 404 for GET /.well-known/oauth-authorization-server', async () => {
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      undefined,
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('GET', '/.well-known/oauth-authorization-server', { host: '127.0.0.1:3000' });
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(res.statusCode).toBe(404);
+    const parsed = JSON.parse(res.body) as Record<string, unknown>;
+    expect(parsed.error).toBe('not_found');
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for GET /oauth/authorize', async () => {
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      undefined,
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('GET', '/oauth/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A9999%2Fcallback&state=abc', {
+      host: '127.0.0.1:3000',
+    });
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(res.statusCode).toBe(404);
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for POST /oauth/register', async () => {
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      undefined,
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('POST', '/oauth/register', { host: '127.0.0.1:3000' }, '{}');
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(res.statusCode).toBe(404);
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for POST /oauth/token', async () => {
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      undefined,
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('POST', '/oauth/token', { host: '127.0.0.1:3000' }, 'grant_type=authorization_code');
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(res.statusCode).toBe(404);
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for GET /oauth/callback', async () => {
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      undefined,
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('GET', '/oauth/callback?code=abc&state=xyz', { host: '127.0.0.1:3000' });
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(res.statusCode).toBe(404);
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+
+  it('still returns 401 with WWW-Authenticate for /mcp without a Bearer token', async () => {
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      undefined,
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('POST', '/mcp');
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.writtenHeaders['WWW-Authenticate']).toBe('Bearer resource="MCP server for Firefly III"');
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+
+  it('still calls mcpHandler with the PAT from the Bearer header for /mcp', async () => {
+    let capturedToken: string | undefined;
+    const mcpHandler = vi.fn().mockImplementation(async () => {
+      capturedToken = requestContext.getStore()?.token;
+    });
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      undefined,
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('POST', '/mcp', { authorization: 'Bearer my-personal-access-token' });
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(mcpHandler).toHaveBeenCalled();
+    expect(capturedToken).toBe('my-personal-access-token');
+  });
+});
+
+describe('startHttpServer — PAT-only mode skips MCP_BASE_URL requirement', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    // Defensively mocked: a regression here must not actually kill the test worker.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null) => {
+      throw new Error('process.exit called');
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.MCP_BASE_URL;
+    vi.restoreAllMocks();
+  });
+
+  it('does not warn or exit when MCP_BASE_URL is unset and oauthClientId is undefined, even on a non-loopback host', async () => {
+    const mockTryListen = vi.fn().mockResolvedValue(undefined);
+    const createMcpServer = vi.fn().mockReturnValue({
+      connect: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await startHttpServer(
+      createMcpServer as unknown as () => import('@modelcontextprotocol/sdk/server/mcp.js').McpServer,
+      '0.0.0.0',
+      3000,
+      false,
+      undefined,
+      'https://firefly.example.com',
+      mockTryListen,
+    );
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const stderrCalls = (process.stderr.write as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) =>
+      String(c[0]),
+    );
+    expect(stderrCalls.some((line) => line.includes('MCP_BASE_URL'))).toBe(false);
+  });
+});
+
 describe('createOAuthHandler — concurrent OAuth flows (P0-1)', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/src/tests/http.test.ts
+++ b/src/tests/http.test.ts
@@ -512,6 +512,62 @@ describe('createOAuthHandler — Bearer guard', () => {
   });
 });
 
+describe('createOAuthHandler — health endpoint', () => {
+  it('returns 200 {status:"ok"} for GET /health without auth (OAuth mode)', async () => {
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      'client-id-123',
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('GET', '/health');
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 for GET /health in PAT-only mode (no oauthClientId)', async () => {
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      undefined,
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('GET', '/health');
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with no body for HEAD /health', async () => {
+    const mcpHandler = vi.fn();
+    const handler = createOAuthHandler(
+      'https://firefly.example.com',
+      'client-id-123',
+      mcpHandler as unknown as (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+    );
+
+    const req = mockReq('HEAD', '/health');
+    const res = mockRes();
+
+    await handler(req as http.IncomingMessage, res as unknown as http.ServerResponse);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('');
+    expect(mcpHandler).not.toHaveBeenCalled();
+  });
+});
+
 describe('createOAuthHandler — PAT-only mode (no oauthClientId)', () => {
   it('returns 404 for GET /.well-known/oauth-authorization-server', async () => {
     const mcpHandler = vi.fn();


### PR DESCRIPTION
Closes #29.

## Summary

Makes `FIREFLY_OAUTH_CLIENT_ID` optional for HTTP transport. When it's unset, the server runs in PAT-only mode: the OAuth proxy surface (`/.well-known/oauth-authorization-server`, `/oauth/authorize`, `/oauth/register`, `/oauth/token`, `/oauth/callback`) 404s instead of being served, and `MCP_BASE_URL` is no longer required (it only existed to build OAuth redirect URIs). Every other request falls straight through to the existing Bearer-token gate exactly as before — which already forwards whatever token it receives to Firefly III as-is, so a Personal Access Token works as a Bearer token with zero changes to that path.

This is for headless callers — gateways, automation — that hold a Firefly III PAT but have no way to drive an interactive, browser-based OAuth flow.

## Changes

- `src/index.ts`: HTTP transport now only requires `FIREFLY_URL`; `FIREFLY_OAUTH_CLIENT_ID` is passed through as optional.
- `src/http.ts`: `createOAuthHandler` accepts `oauthClientId: string | undefined`. Added `isOAuthProxyPath()` and an early 404 guard so the OAuth surface reports itself as absent (rather than serving a half-working flow) when no client ID is configured. `startHttpServer`'s `MCP_BASE_URL` check/warning is now skipped entirely when OAuth isn't enabled.
- `src/tests/http.test.ts`: new `describe` blocks covering the PAT-only 404s, that the Bearer guard and token passthrough still work unauthenticated/authenticated, and that `startHttpServer` doesn't require/warn about `MCP_BASE_URL` in this mode.
- Docs: new `docs/guide/http-pat.md` guide (linked from the sidebar, README, and cross-linked from `http-oauth.md` and `docker.md`), updated `docs/reference/env-vars.md`, `.env.example`, and `AGENTS.md`.
- `CHANGELOG.md`: entry under `## [Unreleased]`.

## Test plan

- [x] `npm run check` (biome + `tsc --noEmit` + full test suite) passes, including 8 new test cases.
- [x] `npm run build` and `npm run docs:build` both succeed.
- [x] Manual smoke test against the built server (`FIREFLY_URL` set, `FIREFLY_OAUTH_CLIENT_ID` unset):
  - `GET /.well-known/oauth-authorization-server` → `404`
  - `POST /mcp` with no `Authorization` header → `401` with `WWW-Authenticate: Bearer`
  - `POST /mcp` with `Authorization: Bearer <token>` (`initialize`) → `200`, valid MCP response
- [x] Existing OAuth-mode behavior is untouched — all pre-existing tests pass unmodified, and `oauthClientId` being set continues through the exact same code paths as before.