### PR TITLE
fix(deps): pin hono to ^4.12.25 to clear npm audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Pinned the transitive `hono` dependency (pulled in by `@modelcontextprotocol/sdk`) to `^4.12.25` via an `overrides` entry, closing a high-severity advisory affecting `hono <=4.12.24` (GHSA-wwfh-h76j-fc44 and related). None of the flagged code paths (`serve-static` on Windows, the AWS Lambda / Lambda@Edge adapters, CORS middleware) are reachable from this server, which uses the raw Node `http` module — but the bump clears the `npm audit --audit-level=moderate` gate in CI. `npm audit` now reports 0 vulnerabilities.
+
 ## [0.2.2] - 2026-06-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2986,9 +2986,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "hono": "^4.12.25"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.0",


### PR DESCRIPTION
## Summary

The `test` jobs in CI fail at the **Audit dependencies (production only)** step (`npm audit --audit-level=moderate --omit=dev`) — not on any test. A high-severity advisory ([GHSA-wwfh-h76j-fc44](https://github.com/advisories/GHSA-wwfh-h76j-fc44) and related) affects `hono <=4.12.24`, a transitive dependency pulled in by `@modelcontextprotocol/sdk`. This blocks `main` and every open PR (including #30).

## Fix

Pin `hono` to `^4.12.25` (the patched release) via the existing `overrides` block in `package.json`. The version satisfies the sdk's `^4.11.4` and `@hono/node-server`'s `^4` constraints, and resolves cleanly to a single deduped `hono@4.12.25`.

## Notes

None of the five flagged code paths are reachable from this server:
- `serve-static` path traversal on Windows
- AWS Lambda / Lambda@Edge adapter header handling
- CORS middleware wildcard-with-credentials

This server uses the raw Node `http` module, none of Hono's middleware or serverless adapters. The bump is purely to clear the `npm audit` gate.

## Verification

- [x] `npm audit --audit-level=moderate --omit=dev` → `found 0 vulnerabilities`
- [x] `npm run check` (biome + `tsc --noEmit` + 392 tests) passes
- [x] `npm ls hono` → single deduped `hono@4.12.25`

🤖 Generated with [Claude Code](https://claude.com/claude-code)