### PR TITLE
fix: map in_id/out_id to inward_id/outward_id for transaction links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `create_transaction_link` and `update_transaction_link` always failed Firefly's validation with "The inward id field is required." / "The outward id field is required.", regardless of the IDs passed in. The tools' exposed schema uses `in_id` / `out_id`, but Firefly III's `/api/v1/transaction-links` endpoint expects `inward_id` / `outward_id` — the request body was forwarded verbatim without renaming these fields. Both functions now map `in_id`/`out_id` to `inward_id`/`outward_id` before calling the API.
+- `create_transaction_link` and `update_transaction_link` always failed Firefly's validation with "The inward id field is required." / "The outward id field is required.", regardless of the IDs passed in. The tools' exposed schema used `in_id` / `out_id`, but Firefly III's `/api/v1/transaction-links` endpoint expects `inward_id` / `outward_id` — the request body was forwarded verbatim without renaming these fields. The schema fields are now renamed to `inward_id` / `outward_id`, matching Firefly's API and the pattern used by every other tool.
 - GitHub Release notes are no longer empty. The `release` job assumed `softprops/action-gh-release` would populate the release body from the annotated tag's message, but it does not — releases were created with blank notes. The workflow now extracts the matching `## [X.Y.Z]` section from `CHANGELOG.md` and passes it via `body_path`.
 
 ## [0.3.0] - 2026-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `create_transaction_link` and `update_transaction_link` always failed Firefly's validation with "The inward id field is required." / "The outward id field is required.", regardless of the IDs passed in. The tools' exposed schema uses `in_id` / `out_id`, but Firefly III's `/api/v1/transaction-links` endpoint expects `inward_id` / `outward_id` — the request body was forwarded verbatim without renaming these fields. Both functions now map `in_id`/`out_id` to `inward_id`/`outward_id` before calling the API.
 - GitHub Release notes are no longer empty. The `release` job assumed `softprops/action-gh-release` would populate the release body from the annotated tag's message, but it does not — releases were created with blank notes. The workflow now extracts the matching `## [X.Y.Z]` section from `CHANGELOG.md` and passes it via `body_path`.
 
 ## [0.3.0] - 2026-06-20

--- a/src/tests/transaction-links.test.ts
+++ b/src/tests/transaction-links.test.ts
@@ -51,13 +51,13 @@ describe('fetchTransactionLink', () => {
 });
 
 describe('createTransactionLink', () => {
-  it('posts to /transaction-links', async () => {
+  it('posts to /transaction-links with in_id/out_id mapped to inward_id/outward_id', async () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(linkSingle);
     await createTransactionLink(mockClient, { link_type_id: '1', in_id: '10', out_id: '11' });
     expect(mockClient.post).toHaveBeenCalledWith('/transaction-links', {
       link_type_id: '1',
-      in_id: '10',
-      out_id: '11',
+      inward_id: '10',
+      outward_id: '11',
     });
   });
 });
@@ -67,6 +67,15 @@ describe('updateTransactionLink', () => {
     mockClient.put = vi.fn().mockResolvedValueOnce(linkSingle);
     await updateTransactionLink(mockClient, '5', { notes: 'related purchase' });
     expect(mockClient.put).toHaveBeenCalledWith('/transaction-links/5', { notes: 'related purchase' });
+  });
+
+  it('maps in_id/out_id to inward_id/outward_id when provided', async () => {
+    mockClient.put = vi.fn().mockResolvedValueOnce(linkSingle);
+    await updateTransactionLink(mockClient, '5', { in_id: '10', out_id: '11' });
+    expect(mockClient.put).toHaveBeenCalledWith('/transaction-links/5', {
+      inward_id: '10',
+      outward_id: '11',
+    });
   });
 });
 

--- a/src/tests/transaction-links.test.ts
+++ b/src/tests/transaction-links.test.ts
@@ -21,7 +21,7 @@ const linkSingle = {
   data: {
     id: '5',
     type: 'transaction_links',
-    attributes: { link_type_id: '1', in_id: '10', out_id: '11', notes: '' },
+    attributes: { link_type_id: '1', inward_id: '10', outward_id: '11', notes: '' },
     links: {},
   },
 };
@@ -51,9 +51,9 @@ describe('fetchTransactionLink', () => {
 });
 
 describe('createTransactionLink', () => {
-  it('posts to /transaction-links with in_id/out_id mapped to inward_id/outward_id', async () => {
+  it('posts to /transaction-links', async () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(linkSingle);
-    await createTransactionLink(mockClient, { link_type_id: '1', in_id: '10', out_id: '11' });
+    await createTransactionLink(mockClient, { link_type_id: '1', inward_id: '10', outward_id: '11' });
     expect(mockClient.post).toHaveBeenCalledWith('/transaction-links', {
       link_type_id: '1',
       inward_id: '10',
@@ -67,15 +67,6 @@ describe('updateTransactionLink', () => {
     mockClient.put = vi.fn().mockResolvedValueOnce(linkSingle);
     await updateTransactionLink(mockClient, '5', { notes: 'related purchase' });
     expect(mockClient.put).toHaveBeenCalledWith('/transaction-links/5', { notes: 'related purchase' });
-  });
-
-  it('maps in_id/out_id to inward_id/outward_id when provided', async () => {
-    mockClient.put = vi.fn().mockResolvedValueOnce(linkSingle);
-    await updateTransactionLink(mockClient, '5', { in_id: '10', out_id: '11' });
-    expect(mockClient.put).toHaveBeenCalledWith('/transaction-links/5', {
-      inward_id: '10',
-      outward_id: '11',
-    });
   });
 });
 

--- a/src/tools/transaction-links.ts
+++ b/src/tools/transaction-links.ts
@@ -39,27 +39,18 @@ export async function fetchTransactionLink(client: FireflyClient, id: string): P
 
 export async function createTransactionLink(
   client: FireflyClient,
-  params: { link_type_id: string; in_id: string; out_id: string; notes?: string },
+  params: { link_type_id: string; inward_id: string; outward_id: string; notes?: string },
 ): Promise<UnwrappedSingle> {
-  const { in_id, out_id, ...rest } = params;
-  const response = await client.post<JsonApiSingleResponse>('/transaction-links', {
-    ...rest,
-    inward_id: in_id,
-    outward_id: out_id,
-  });
+  const response = await client.post<JsonApiSingleResponse>('/transaction-links', params);
   return unwrapSingle(response);
 }
 
 export async function updateTransactionLink(
   client: FireflyClient,
   id: string,
-  params: { link_type_id?: string; in_id?: string; out_id?: string; notes?: string },
+  params: { link_type_id?: string; inward_id?: string; outward_id?: string; notes?: string },
 ): Promise<UnwrappedSingle> {
-  const { in_id, out_id, ...rest } = params;
-  const body: Record<string, unknown> = { ...rest };
-  if (in_id !== undefined) body.inward_id = in_id;
-  if (out_id !== undefined) body.outward_id = out_id;
-  const response = await client.put<JsonApiSingleResponse>(`/transaction-links/${id}`, body);
+  const response = await client.put<JsonApiSingleResponse>(`/transaction-links/${id}`, params);
   return unwrapSingle(response);
 }
 
@@ -128,8 +119,8 @@ export function registerTransactionLinkTools(server: McpServer, client: FireflyC
         'Create a link between two transactions (e.g. mark one as a refund of another). Use get_link_types to find valid link_type_id values.',
       inputSchema: {
         link_type_id: z.string().describe('Link type ID — use get_link_types to find valid IDs'),
-        in_id: z.string().describe('Inward transaction journal ID'),
-        out_id: z.string().describe('Outward transaction journal ID'),
+        inward_id: z.string().describe('Inward transaction journal ID'),
+        outward_id: z.string().describe('Outward transaction journal ID'),
         notes: z.string().optional().describe('Notes about this link'),
       },
       annotations: WRITE_ANNOTATIONS,
@@ -146,8 +137,8 @@ export function registerTransactionLinkTools(server: McpServer, client: FireflyC
       inputSchema: {
         id: z.string().describe('Transaction link ID'),
         link_type_id: z.string().optional().describe('Link type ID'),
-        in_id: z.string().optional().describe('Inward transaction journal ID'),
-        out_id: z.string().optional().describe('Outward transaction journal ID'),
+        inward_id: z.string().optional().describe('Inward transaction journal ID'),
+        outward_id: z.string().optional().describe('Outward transaction journal ID'),
         notes: z.string().optional().describe('Notes about this link'),
       },
       annotations: UPDATE_ANNOTATIONS,

--- a/src/tools/transaction-links.ts
+++ b/src/tools/transaction-links.ts
@@ -41,7 +41,12 @@ export async function createTransactionLink(
   client: FireflyClient,
   params: { link_type_id: string; in_id: string; out_id: string; notes?: string },
 ): Promise<UnwrappedSingle> {
-  const response = await client.post<JsonApiSingleResponse>('/transaction-links', params);
+  const { in_id, out_id, ...rest } = params;
+  const response = await client.post<JsonApiSingleResponse>('/transaction-links', {
+    ...rest,
+    inward_id: in_id,
+    outward_id: out_id,
+  });
   return unwrapSingle(response);
 }
 
@@ -50,7 +55,11 @@ export async function updateTransactionLink(
   id: string,
   params: { link_type_id?: string; in_id?: string; out_id?: string; notes?: string },
 ): Promise<UnwrappedSingle> {
-  const response = await client.put<JsonApiSingleResponse>(`/transaction-links/${id}`, params);
+  const { in_id, out_id, ...rest } = params;
+  const body: Record<string, unknown> = { ...rest };
+  if (in_id !== undefined) body.inward_id = in_id;
+  if (out_id !== undefined) body.outward_id = out_id;
+  const response = await client.put<JsonApiSingleResponse>(`/transaction-links/${id}`, body);
   return unwrapSingle(response);
 }
 


### PR DESCRIPTION
Firefly III's /api/v1/transaction-links endpoint expects inward_id and outward_id, but the request body was forwarded verbatim with the tool's in_id/out_id field names, so every create/update call failed validation regardless of the IDs passed in.

Fixes #36 