### PR TITLE
fix(security): override @hono/node-server to ^2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- **Forced the transitive `@hono/node-server` dependency to ^2.0.5 via an npm override**, resolving [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) (medium severity), a path traversal in its `serve-static` module on Windows via encoded backslashes. The package comes in through `@modelcontextprotocol/sdk`, which pins `^1.19.9` — below the patched 2.0.5. This server was not exploitable: the SDK only uses `serve`/`getRequestListener`, never the vulnerable `serveStatic`, and the flaw is Windows-only. The override closes the alert until the SDK moves to 2.x upstream.
+
 ## [0.3.3] - 2026-07-21
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,9 +159,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -179,9 +176,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -199,9 +193,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -219,9 +210,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -763,12 +751,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -981,9 +969,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1001,9 +986,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1021,9 +1003,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1041,9 +1020,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1061,9 +1037,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1081,9 +1054,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "zod": "^4.4.3"
   },
   "overrides": {
+    "@hono/node-server": "^2.0.5",
     "esbuild": "^0.28.1",
     "hono": "^4.12.31"
   },


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #10](https://github.com/daften/fireflyiii-mcp/security/dependabot/10) / [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) (medium severity): path traversal in `@hono/node-server`'s `serve-static` module on Windows via encoded backslash (`%5C`), fixed in 2.0.5.

## Why Dependabot couldn't fix it

The package is a transitive dependency of `@modelcontextprotocol/sdk`, which pins `^1.19.9` — even the latest SDK release (1.29.0) hasn't moved to 2.x. Since 2.0.5 is a major bump outside that semver range, Dependabot had no compatible update path.

## The fix

Adds `"@hono/node-server": "^2.0.5"` to the existing `overrides` block in `package.json` (same pattern already used for `hono` and `esbuild`). Resolves to 2.0.11. Safe because:

- v2 requires Node ≥20 and `hono@^4` as a peer — both already satisfied by this project
- The SDK only imports `serve` and `getRequestListener`, both unchanged in v2

Also adds a `## [Unreleased]` changelog entry, since AGENTS.md requires security-relevant dependency bumps to be recorded.

## Actual exposure

Nil: the SDK never uses the vulnerable `serveStatic`, and the flaw is Windows-only. The override closes the alert until the SDK moves to 2.x upstream.

## Verification

- `npm audit`: 0 vulnerabilities
- `npm run check` (biome, tsc, vitest): all green, 418 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)