### PR TITLE
feat: support date-time values for transaction writes

### DIFF
--- a/src/tests/helpers.test.ts
+++ b/src/tests/helpers.test.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { describe, expect, it, vi } from 'vitest';
 import { FireflyError } from '../client.js';
-import { dateSchema, defineTool, parseId } from '../tools/_helpers.js';
+import { dateOrDateTimeSchema, dateSchema, defineTool, parseId } from '../tools/_helpers.js';
 
 function makeServer() {
   let capturedHandler: ((args: Record<string, unknown>) => Promise<unknown>) | null = null;
@@ -73,6 +73,29 @@ describe('dateSchema', () => {
 
   it('rejects natural-language dates', () => {
     expect(() => dateSchema.parse('Jan 15 2026')).toThrow('Date must be YYYY-MM-DD');
+  });
+});
+
+describe('dateOrDateTimeSchema', () => {
+  it('accepts YYYY-MM-DD for backward compatibility', () => {
+    expect(() => dateOrDateTimeSchema.parse('2026-01-15')).not.toThrow();
+  });
+
+  it('accepts RFC 3339 date-times with UTC or an explicit offset', () => {
+    expect(() => dateOrDateTimeSchema.parse('2026-07-25T12:30:00Z')).not.toThrow();
+    expect(() => dateOrDateTimeSchema.parse('2026-07-25T14:30:00+02:00')).not.toThrow();
+  });
+
+  it('rejects date-times without a timezone', () => {
+    expect(() => dateOrDateTimeSchema.parse('2026-07-25T14:30:00')).toThrow(
+      'Date must be YYYY-MM-DD or an RFC 3339 date-time with timezone',
+    );
+  });
+
+  it('rejects invalid date-times', () => {
+    expect(() => dateOrDateTimeSchema.parse('2026-02-30T12:30:00Z')).toThrow(
+      'Date must be YYYY-MM-DD or an RFC 3339 date-time with timezone',
+    );
   });
 });
 

--- a/src/tests/transactions.test.ts
+++ b/src/tests/transactions.test.ts
@@ -99,7 +99,7 @@ describe('createTransaction', () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(writeSingleFixture);
     await createTransaction(mockClient, {
       type: 'withdrawal',
-      date: '2024-01-15',
+      date: '2024-01-15T09:30:00Z',
       amount: '42.50',
       description: 'Groceries',
       source_id: '1',
@@ -110,7 +110,7 @@ describe('createTransaction', () => {
       transactions: [
         expect.objectContaining({
           type: 'withdrawal',
-          date: '2024-01-15',
+          date: '2024-01-15T09:30:00Z',
           amount: '42.50',
           description: 'Groceries',
           source_id: '1',
@@ -134,11 +134,14 @@ describe('createTransaction', () => {
 describe('updateTransaction', () => {
   it('puts to /transactions/:id with wrapped body', async () => {
     mockClient.put = vi.fn().mockResolvedValueOnce(writeSingleFixture);
-    await updateTransaction(mockClient, '5', { description: 'Updated' });
+    await updateTransaction(mockClient, '5', {
+      date: '2024-01-15T11:30:00+02:00',
+      description: 'Updated',
+    });
     expect(mockClient.put).toHaveBeenCalledWith('/transactions/5', {
       apply_rules: true,
       fire_webhooks: true,
-      transactions: [{ description: 'Updated' }],
+      transactions: [{ date: '2024-01-15T11:30:00+02:00', description: 'Updated' }],
     });
   });
 
@@ -187,7 +190,7 @@ describe('createSplitTransaction', () => {
     mockClient.post = vi.fn().mockResolvedValueOnce(writeSingleFixture);
     await createSplitTransaction(mockClient, {
       type: 'withdrawal',
-      date: '2026-05-01',
+      date: '2026-05-01T18:45:00-04:00',
       source_id: '1',
       splits: [
         { amount: '30.00', description: 'Groceries', category_name: 'Food' },
@@ -200,7 +203,7 @@ describe('createSplitTransaction', () => {
       transactions: [
         {
           type: 'withdrawal',
-          date: '2026-05-01',
+          date: '2026-05-01T18:45:00-04:00',
           source_id: '1',
           amount: '30.00',
           description: 'Groceries',
@@ -208,7 +211,7 @@ describe('createSplitTransaction', () => {
         },
         {
           type: 'withdrawal',
-          date: '2026-05-01',
+          date: '2026-05-01T18:45:00-04:00',
           source_id: '1',
           amount: '12.50',
           description: 'Cleaning supplies',

--- a/src/tools/_helpers.ts
+++ b/src/tools/_helpers.ts
@@ -70,6 +70,13 @@ export function defineContentTool(
 
 export const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD');
 
+const dateTimeSchema = z.iso.datetime({ offset: true });
+export const dateOrDateTimeSchema = z
+  .string()
+  .refine((value) => dateSchema.safeParse(value).success || dateTimeSchema.safeParse(value).success, {
+    message: 'Date must be YYYY-MM-DD or an RFC 3339 date-time with timezone',
+  });
+
 /**
  * Extracts a leading numeric ID from an autocomplete label such as `"42 (Checking - asset)"`.
  *

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -11,7 +11,7 @@ import {
 } from '../transform.js';
 import type { QueryParams } from '../types.js';
 import { DELETE_ANNOTATIONS, READ_ANNOTATIONS, UPDATE_ANNOTATIONS, WRITE_ANNOTATIONS } from './_annotations.js';
-import { dateSchema, defineTool } from './_helpers.js';
+import { dateOrDateTimeSchema, dateSchema, defineTool } from './_helpers.js';
 
 export async function fetchTransactions(
   client: FireflyClient,
@@ -237,7 +237,7 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
         'Create a new transaction in Firefly III. Use get_accounts to find source and destination account IDs.',
       inputSchema: {
         type: z.enum(['withdrawal', 'deposit', 'transfer']).describe('Transaction type'),
-        date: dateSchema.describe('Transaction date (YYYY-MM-DD)'),
+        date: dateOrDateTimeSchema.describe('Transaction date (YYYY-MM-DD or RFC 3339 date-time with timezone)'),
         amount: z.string().describe('Amount as a positive number string, e.g. "42.50"'),
         description: z.string().describe('Short description of the transaction'),
         source_id: z.string().optional().describe('Source account ID (required for withdrawals and transfers)'),
@@ -263,7 +263,9 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
       inputSchema: {
         id: z.string().describe('Transaction ID — use get_transactions to find valid IDs'),
         type: z.enum(['withdrawal', 'deposit', 'transfer']).optional().describe('Transaction type'),
-        date: dateSchema.optional().describe('Transaction date (YYYY-MM-DD)'),
+        date: dateOrDateTimeSchema
+          .optional()
+          .describe('Transaction date (YYYY-MM-DD or RFC 3339 date-time with timezone)'),
         amount: z.string().optional().describe('Amount as a positive number string'),
         description: z.string().optional().describe('Short description'),
         source_id: z.string().optional().describe('Source account ID'),
@@ -325,7 +327,9 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
         'Create a split transaction in Firefly III — one receipt divided across multiple categories, budgets, or descriptions. All splits share the same type, date, and accounts. Use get_accounts to find source and destination account IDs.',
       inputSchema: {
         type: z.enum(['withdrawal', 'deposit', 'transfer']).describe('Transaction type (shared across all splits)'),
-        date: dateSchema.describe('Transaction date (YYYY-MM-DD, shared across all splits)'),
+        date: dateOrDateTimeSchema.describe(
+          'Transaction date (YYYY-MM-DD or RFC 3339 date-time with timezone, shared across all splits)',
+        ),
         source_id: z.string().optional().describe('Source account ID (required for withdrawals and transfers)'),
         destination_id: z.string().optional().describe('Destination account ID (required for deposits and transfers)'),
         currency_code: z.string().optional().describe('Currency code (e.g. EUR, USD). Defaults to account currency.'),


### PR DESCRIPTION
## Summary

Hi, first of all, thank you for creating and maintaining this tool!

I noticed this while trying to add a transaction using the MCP tool. I wanted to include the transaction time, but the tool only accepted a date in the `YYYY-MM-DD` format.

After checking the official Firefly III API, I found that the transaction date field supports a date-time value, so I thought it would be useful for the MCP tool to support this as well.

I've tried deployed the updated image, then tested creating transactions with date-time values through the MCP tool. It seems to be working correctly on my setup.

This change may also help address issue #60.

This PR allows transaction tools to accept either:

* A date, such as `2026-07-26`
* An RFC 3339 date-time with a timezone, such as `2026-07-26T14:30:00+07:00`

I kept the existing date-only format for backwards compatibility.

## Changes

* Added `dateOrDateTimeSchema` a reusable schema that accepts either a date or an RFC 3339 date-time
* Updated the create, update, and split transaction tools to use the new schema
* Added tests for valid and invalid date-time values

## Type of change

- [x] feat (new tool or feature)
- [ ] fix (bug fix)
- [ ] refactor (code cleanup, no behavior change)
- [x] test (add or update tests)
- [ ] chore (dependencies, config, scaffolding)
- [ ] docs (documentation only)

## Checklist

- [x] Tests added or updated
- [x] `npm test` passes locally
- [x] `npx tsc --noEmit` passes locally
- [ ] README tool table updated (if a new tool was added)
- [ ] CLAUDE.md updated (if architectural)
- [x] Verified relevant fields against the [Firefly III OpenAPI spec](https://api-docs.firefly-iii.org/) (if API-touching)
