### PR TITLE
fix(ci): populate alert-state in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,6 +28,7 @@ jobs:
         uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-lookup: true
 
       # alert-state is non-empty only for PRs that fix a security advisory.
       # Merge commit, never squash: this repo keeps merge commits everywhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `auto-merge.yml` never actually enabled auto-merge on Dependabot security PRs: the `dependabot/fetch-metadata` step omitted `alert-lookup: true`, so `alert-state` was always empty and the merge step's guard condition was never true. Added `alert-lookup: true` to populate it.
+
 ## [0.4.0] - 2026-08-02
 
 ### Added


### PR DESCRIPTION
## Summary
- `auto-merge.yml`'s \`Fetch Dependabot metadata\` step called \`dependabot/fetch-metadata@v3\` without \`alert-lookup: true\`. Per the action's own \`action.yml\`, \`alert-state\`/\`ghsa-id\`/\`cvss\` are only populated when that input is set — otherwise they're always empty.
- The "Enable auto-merge" step is gated on \`steps.meta.outputs.alert-state != ''\`, so it has never actually fired for any Dependabot security PR since the workflow was introduced.
- Confirmed against PR #69's run logs: \`outputs.alert-state:\` (blank), \`outputs.ghsa-id:\` (blank), \`outputs.cvss: 0\`.

## Test plan
- [x] `npm run check` (biome, tsc, vitest) passes locally via pre-commit hook
- [ ] Next Dependabot security PR against `main` should have auto-merge enabled by this workflow (verify `steps.meta.outputs.alert-state` is populated in the run log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)