### PR TITLE
fix(accounts): add liability_type/liability_direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `create_account` and `update_account` were missing `liability_type` and `liability_direction`, which the Firefly III API requires when `type` is `liability`. Creating or updating a debt/loan/mortgage account failed with a validation error and no way to supply the required fields. Both are now accepted as optional enums on both tools.
+- `category_name` on `create_transaction`, `update_transaction`, `create_split_transaction`, and `bulk_update_transactions`, and `name` on `create_category`/`update_category`, are now decoded for a small set of common HTML entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`/`&apos;`) before being sent to Firefly. A name copied from rendered HTML (e.g. "Restaurants &amp; cafés") previously matched nothing by exact string and silently created a duplicate category instead of the intended one.
 
 ## [0.4.2] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `create_account` and `update_account` were missing `liability_type` and `liability_direction`, which the Firefly III API requires when `type` is `liability`. Creating or updating a debt/loan/mortgage account failed with a validation error and no way to supply the required fields. Both are now accepted as optional enums on both tools.
+
 ## [0.4.2] - 2026-08-04
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `create_account` and `update_account` were missing `liability_type` and `liability_direction`, which the Firefly III API requires when `type` is `liability`. Creating or updating a debt/loan/mortgage account failed with a validation error and no way to supply the required fields. Both are now accepted as optional enums on both tools.
 - `category_name` on `create_transaction`, `update_transaction`, `create_split_transaction`, and `bulk_update_transactions`, and `name` on `create_category`/`update_category`, are now decoded for a small set of common HTML entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`/`&apos;`) before being sent to Firefly. A name copied from rendered HTML (e.g. "Restaurants &amp; cafés") previously matched nothing by exact string and silently created a duplicate category instead of the intended one.
 
+### Changed
+- `get_transaction`, `create_transaction`, `update_transaction`, and `delete_transaction` now explicitly warn in their descriptions that a transaction response's top-level `id` (the transaction GROUP id) is what update/delete expect — not the `transaction_journal_id` nested inside each item of the response's `transactions` array, a different, usually adjacent, number. Passing the journal id previously silently edited or deleted an unrelated transaction with no error.
+
 ## [0.4.2] - 2026-08-04
 
 ### Security

--- a/src/tests/accounts.test.ts
+++ b/src/tests/accounts.test.ts
@@ -101,6 +101,21 @@ describe('createAccount', () => {
     const result = await createAccount(mockClient, { name: 'New Account', type: 'asset' });
     expect(result).toEqual({ name: 'New Account', type: 'asset', active: true, id: '10' });
   });
+  it('posts liability_type and liability_direction when type is liability', async () => {
+    mockClient.post = vi.fn().mockResolvedValueOnce(accountSingleFixture);
+    await createAccount(mockClient, {
+      name: 'Credit line',
+      type: 'liability',
+      liability_type: 'debt',
+      liability_direction: 'debit',
+    });
+    expect(mockClient.post).toHaveBeenCalledWith('/accounts', {
+      name: 'Credit line',
+      type: 'liability',
+      liability_type: 'debt',
+      liability_direction: 'debit',
+    });
+  });
 });
 
 describe('updateAccount', () => {
@@ -108,6 +123,14 @@ describe('updateAccount', () => {
     mockClient.put = vi.fn().mockResolvedValueOnce(accountSingleFixture);
     await updateAccount(mockClient, '10', { name: 'Renamed' });
     expect(mockClient.put).toHaveBeenCalledWith('/accounts/10', { name: 'Renamed' });
+  });
+  it('puts liability_type and liability_direction when provided', async () => {
+    mockClient.put = vi.fn().mockResolvedValueOnce(accountSingleFixture);
+    await updateAccount(mockClient, '10', { liability_type: 'loan', liability_direction: 'debit' });
+    expect(mockClient.put).toHaveBeenCalledWith('/accounts/10', {
+      liability_type: 'loan',
+      liability_direction: 'debit',
+    });
   });
   it('returns unwrapped single', async () => {
     mockClient.put = vi.fn().mockResolvedValueOnce(accountSingleFixture);

--- a/src/tests/categories.test.ts
+++ b/src/tests/categories.test.ts
@@ -85,6 +85,12 @@ describe('createCategory', () => {
     const result = await createCategory(mockClient, { name: 'Groceries' });
     expect(result).toEqual({ name: 'Groceries', id: '8' });
   });
+
+  it('decodes HTML entities in the name before sending', async () => {
+    mockClient.post = vi.fn().mockResolvedValueOnce(categorySingleFixture);
+    await createCategory(mockClient, { name: 'Restaurants &amp; cafés' });
+    expect(mockClient.post).toHaveBeenCalledWith('/categories', { name: 'Restaurants & cafés' });
+  });
 });
 
 describe('updateCategory', () => {
@@ -92,6 +98,18 @@ describe('updateCategory', () => {
     mockClient.put = vi.fn().mockResolvedValueOnce(categorySingleFixture);
     await updateCategory(mockClient, '8', { name: 'Food' });
     expect(mockClient.put).toHaveBeenCalledWith('/categories/8', { name: 'Food' });
+  });
+
+  it('decodes HTML entities in the name before sending', async () => {
+    mockClient.put = vi.fn().mockResolvedValueOnce(categorySingleFixture);
+    await updateCategory(mockClient, '8', { name: 'Restaurants &amp; cafés' });
+    expect(mockClient.put).toHaveBeenCalledWith('/categories/8', { name: 'Restaurants & cafés' });
+  });
+
+  it('does not touch notes-only updates', async () => {
+    mockClient.put = vi.fn().mockResolvedValueOnce(categorySingleFixture);
+    await updateCategory(mockClient, '8', { notes: 'no name change' });
+    expect(mockClient.put).toHaveBeenCalledWith('/categories/8', { notes: 'no name change' });
   });
 });
 

--- a/src/tests/helpers.test.ts
+++ b/src/tests/helpers.test.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { describe, expect, it, vi } from 'vitest';
 import { FireflyError } from '../client.js';
-import { dateOrDateTimeSchema, dateSchema, defineTool, parseId } from '../tools/_helpers.js';
+import { dateOrDateTimeSchema, dateSchema, decodeHtmlEntities, defineTool, parseId } from '../tools/_helpers.js';
 
 function makeServer() {
   let capturedHandler: ((args: Record<string, unknown>) => Promise<unknown>) | null = null;
@@ -111,5 +111,32 @@ describe('parseId', () => {
 
   it('falls back to input if no leading numeric ID is found', () => {
     expect(parseId('no-numbers')).toBe('no-numbers');
+  });
+});
+
+describe('decodeHtmlEntities', () => {
+  it('decodes an ampersand entity', () => {
+    expect(decodeHtmlEntities('Restaurants &amp; cafés')).toBe('Restaurants & cafés');
+  });
+
+  it('decodes multiple distinct entities in one string', () => {
+    expect(decodeHtmlEntities('&lt;Tom &amp; Jerry&gt;')).toBe('<Tom & Jerry>');
+  });
+
+  it('decodes quote and apostrophe entities', () => {
+    expect(decodeHtmlEntities('&quot;Mom&#39;s&quot; café')).toBe('"Mom\'s" café');
+    expect(decodeHtmlEntities('Mom&apos;s')).toBe("Mom's");
+  });
+
+  it('leaves plain text with a literal ampersand unchanged', () => {
+    expect(decodeHtmlEntities('Restaurants & cafés')).toBe('Restaurants & cafés');
+  });
+
+  it('leaves strings with no entities unchanged', () => {
+    expect(decodeHtmlEntities('Groceries')).toBe('Groceries');
+  });
+
+  it('ignores unsupported entities', () => {
+    expect(decodeHtmlEntities('Café &euro; menu')).toBe('Café &euro; menu');
   });
 });

--- a/src/tests/transactions.test.ts
+++ b/src/tests/transactions.test.ts
@@ -129,6 +129,21 @@ describe('createTransaction', () => {
     });
     expect(result).toEqual({ description: 'Groceries', amount: '42.50', type: 'withdrawal', id: '5' });
   });
+
+  it('decodes HTML entities in category_name before sending', async () => {
+    mockClient.post = vi.fn().mockResolvedValueOnce(writeSingleFixture);
+    await createTransaction(mockClient, {
+      type: 'withdrawal',
+      date: '2024-01-15',
+      amount: '42.50',
+      description: 'Dinner',
+      category_name: 'Restaurants &amp; cafés',
+    });
+    const body = (mockClient.post as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      transactions: Array<{ category_name?: string }>;
+    };
+    expect(body.transactions[0].category_name).toBe('Restaurants & cafés');
+  });
 });
 
 describe('updateTransaction', () => {
@@ -149,6 +164,15 @@ describe('updateTransaction', () => {
     mockClient.put = vi.fn().mockResolvedValueOnce(writeSingleFixture);
     const result = await updateTransaction(mockClient, '5', { amount: '50.00' });
     expect(result).toEqual({ description: 'Groceries', amount: '42.50', type: 'withdrawal', id: '5' });
+  });
+
+  it('decodes HTML entities in category_name before sending', async () => {
+    mockClient.put = vi.fn().mockResolvedValueOnce(writeSingleFixture);
+    await updateTransaction(mockClient, '5', { category_name: 'Tom &amp; Jerry' });
+    const body = (mockClient.put as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      transactions: Array<{ category_name?: string }>;
+    };
+    expect(body.transactions[0].category_name).toBe('Tom & Jerry');
   });
 });
 
@@ -269,6 +293,19 @@ describe('createSplitTransaction', () => {
     expect(body.transactions[0]).not.toHaveProperty('destination_id');
     expect(body.transactions[0]).not.toHaveProperty('currency_code');
   });
+
+  it('decodes HTML entities in each split category_name before sending', async () => {
+    mockClient.post = vi.fn().mockResolvedValueOnce(writeSingleFixture);
+    await createSplitTransaction(mockClient, {
+      type: 'withdrawal',
+      date: '2026-05-01',
+      splits: [{ amount: '30.00', description: 'Dinner', category_name: 'Restaurants &amp; cafés' }],
+    });
+    const body = (mockClient.post as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      transactions: Array<{ category_name?: string }>;
+    };
+    expect(body.transactions[0].category_name).toBe('Restaurants & cafés');
+  });
 });
 
 describe('bulkUpdateTransactions', () => {
@@ -278,6 +315,18 @@ describe('bulkUpdateTransactions', () => {
     expect(mockClient.post).toHaveBeenCalledWith('/data/bulk/transactions', undefined, {
       query: JSON.stringify({ where: 'description:coffee', update: { category_name: 'Food', budget_id: '3' } }),
     });
+  });
+
+  it('decodes HTML entities in category_name before sending', async () => {
+    mockClient.post = vi.fn().mockResolvedValueOnce(undefined);
+    await bulkUpdateTransactions(mockClient, { query: 'description:coffee', category_name: 'Restaurants &amp; cafés' });
+    const call = (mockClient.post as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      unknown,
+      Record<string, string>,
+    ];
+    const sentQuery = JSON.parse(call[2].query) as { update: Record<string, unknown> };
+    expect(sentQuery.update.category_name).toBe('Restaurants & cafés');
   });
 
   it('omits undefined update fields from the JSON query', async () => {

--- a/src/tests/transactions.test.ts
+++ b/src/tests/transactions.test.ts
@@ -359,4 +359,22 @@ describe('handler smoke — transactions', () => {
     const result = await handlers.get('get_transactions')!({});
     expect(result).toMatchObject({ isError: true });
   });
+
+  // Regression test for a real mistake: transaction responses carry two different ids — the
+  // top-level group `id` (what update/delete expect) and a `transaction_journal_id` nested inside
+  // each item of `transactions[]` (usually an adjacent number). Passing the journal id to
+  // update_transaction/delete_transaction silently edits or deletes a different transaction. These
+  // assertions make sure the warning stays present if the tool descriptions are ever reworded.
+  it('warns against transaction_journal_id in id-accepting tool descriptions', () => {
+    const { server, toolConfigs } = createMockServer();
+    registerTransactionTools(server, {} as unknown as FireflyClient);
+    for (const name of ['get_transaction', 'create_transaction', 'update_transaction', 'delete_transaction']) {
+      const config = toolConfigs.get(name);
+      const text =
+        name === 'update_transaction' || name === 'delete_transaction'
+          ? config.inputSchema.id.description
+          : config.description;
+      expect(text, `${name} should warn about transaction_journal_id`).toContain('transaction_journal_id');
+    }
+  });
 });

--- a/src/tools/_helpers.ts
+++ b/src/tools/_helpers.ts
@@ -70,6 +70,27 @@ export function defineContentTool(
 
 export const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD');
 
+const HTML_ENTITY_MAP: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&apos;': "'",
+};
+
+/**
+ * Decodes the small set of HTML entities a name can pick up when copied from rendered HTML (e.g.
+ * "Restaurants &amp; cafés" pasted from a web page). Firefly matches category/tag names by exact
+ * string, so an un-decoded entity silently creates a duplicate ("Restaurants &amp; cafés") instead
+ * of matching the intended category — the mismatch is easy to miss since both names render
+ * identically in most UIs. Deliberately narrow: only the handful of entities realistic in a plain
+ * name, not a general HTML decoder.
+ */
+export function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(?:amp|lt|gt|quot|#39|apos);/g, (match) => HTML_ENTITY_MAP[match] ?? match);
+}
+
 const dateTimeSchema = z.iso.datetime({ offset: true });
 export const dateOrDateTimeSchema = z
   .string()

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -43,6 +43,8 @@ export async function createAccount(
     name: string;
     type: 'asset' | 'expense' | 'revenue' | 'liability';
     account_role?: 'defaultAsset' | 'sharedAsset' | 'savingAsset' | 'ccAsset' | 'cashWalletAsset';
+    liability_type?: 'loan' | 'debt' | 'mortgage';
+    liability_direction?: 'credit' | 'debit';
     currency_code?: string;
     iban?: string;
     opening_balance?: string;
@@ -67,6 +69,8 @@ export async function updateAccount(
     include_net_worth?: boolean;
     active?: boolean;
     notes?: string;
+    liability_type?: 'loan' | 'debt' | 'mortgage';
+    liability_direction?: 'credit' | 'debit';
   },
 ): Promise<UnwrappedSingle> {
   const response = await client.put<JsonApiSingleResponse>(`/accounts/${id}`, params);
@@ -183,6 +187,16 @@ export function registerAccountTools(server: McpServer, client: FireflyClient): 
           .enum(['defaultAsset', 'sharedAsset', 'savingAsset', 'ccAsset', 'cashWalletAsset'])
           .optional()
           .describe('Role for asset accounts (required when type is asset)'),
+        liability_type: z
+          .enum(['loan', 'debt', 'mortgage'])
+          .optional()
+          .describe('Liability type (required when type is liability): loan, debt, or mortgage'),
+        liability_direction: z
+          .enum(['credit', 'debit'])
+          .optional()
+          .describe(
+            "Liability direction (required when type is liability): 'debit' if you owe this money, 'credit' if it is owed to you",
+          ),
         currency_code: z.string().optional().describe('Currency code (e.g. EUR, USD)'),
         iban: z.string().optional().describe('IBAN number'),
         opening_balance: z.string().optional().describe('Opening balance as a number string'),
@@ -212,6 +226,16 @@ export function registerAccountTools(server: McpServer, client: FireflyClient): 
         include_net_worth: z.boolean().optional().describe('Include in net worth calculations'),
         active: z.boolean().optional().describe('Whether the account is active'),
         notes: z.string().optional().describe('Notes'),
+        liability_type: z
+          .enum(['loan', 'debt', 'mortgage'])
+          .optional()
+          .describe('Liability type (required when type is liability): loan, debt, or mortgage'),
+        liability_direction: z
+          .enum(['credit', 'debit'])
+          .optional()
+          .describe(
+            "Liability direction (required when type is liability): 'debit' if you owe this money, 'credit' if it is owed to you",
+          ),
       },
       annotations: UPDATE_ANNOTATIONS,
     },

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -18,6 +18,7 @@ import {
   createTtlCache,
   dateSchema,
   debugLog,
+  decodeHtmlEntities,
   defineTool,
   parseId,
 } from './_helpers.js';
@@ -46,7 +47,8 @@ export async function createCategory(
   client: FireflyClient,
   params: { name: string; notes?: string },
 ): Promise<UnwrappedSingle> {
-  const response = await client.post<JsonApiSingleResponse>('/categories', params);
+  const body = { ...params, name: decodeHtmlEntities(params.name) };
+  const response = await client.post<JsonApiSingleResponse>('/categories', body);
   return unwrapSingle(response);
 }
 
@@ -55,7 +57,8 @@ export async function updateCategory(
   id: string,
   params: { name?: string; notes?: string },
 ): Promise<UnwrappedSingle> {
-  const response = await client.put<JsonApiSingleResponse>(`/categories/${id}`, params);
+  const body = params.name !== undefined ? { ...params, name: decodeHtmlEntities(params.name) } : params;
+  const response = await client.put<JsonApiSingleResponse>(`/categories/${id}`, body);
   return unwrapSingle(response);
 }
 

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -11,7 +11,7 @@ import {
 } from '../transform.js';
 import type { QueryParams } from '../types.js';
 import { DELETE_ANNOTATIONS, READ_ANNOTATIONS, UPDATE_ANNOTATIONS, WRITE_ANNOTATIONS } from './_annotations.js';
-import { dateOrDateTimeSchema, dateSchema, defineTool } from './_helpers.js';
+import { dateOrDateTimeSchema, dateSchema, decodeHtmlEntities, defineTool } from './_helpers.js';
 
 export async function fetchTransactions(
   client: FireflyClient,
@@ -62,7 +62,7 @@ export async function createTransaction(
   };
   if (params.source_id !== undefined) split.source_id = params.source_id;
   if (params.destination_id !== undefined) split.destination_id = params.destination_id;
-  if (params.category_name !== undefined) split.category_name = params.category_name;
+  if (params.category_name !== undefined) split.category_name = decodeHtmlEntities(params.category_name);
   if (params.budget_id !== undefined) split.budget_id = params.budget_id;
   if (params.currency_code !== undefined) split.currency_code = params.currency_code;
   if (params.notes !== undefined) split.notes = params.notes;
@@ -99,7 +99,7 @@ export async function updateTransaction(
   if (params.description !== undefined) split.description = params.description;
   if (params.source_id !== undefined) split.source_id = params.source_id;
   if (params.destination_id !== undefined) split.destination_id = params.destination_id;
-  if (params.category_name !== undefined) split.category_name = params.category_name;
+  if (params.category_name !== undefined) split.category_name = decodeHtmlEntities(params.category_name);
   if (params.budget_id !== undefined) split.budget_id = params.budget_id;
   if (params.currency_code !== undefined) split.currency_code = params.currency_code;
   if (params.notes !== undefined) split.notes = params.notes;
@@ -131,7 +131,7 @@ export async function bulkUpdateTransactions(
   params: { query: string; category_name?: string; budget_id?: string; tags?: string[]; notes?: string },
 ): Promise<unknown> {
   const update: Record<string, unknown> = {};
-  if (params.category_name !== undefined) update.category_name = params.category_name;
+  if (params.category_name !== undefined) update.category_name = decodeHtmlEntities(params.category_name);
   if (params.budget_id !== undefined) update.budget_id = params.budget_id;
   if (params.tags !== undefined) update.tags = params.tags;
   if (params.notes !== undefined) update.notes = params.notes;
@@ -169,7 +169,7 @@ export async function createSplitTransaction(
     if (params.source_id !== undefined) item.source_id = params.source_id;
     if (params.destination_id !== undefined) item.destination_id = params.destination_id;
     if (params.currency_code !== undefined) item.currency_code = params.currency_code;
-    if (split.category_name !== undefined) item.category_name = split.category_name;
+    if (split.category_name !== undefined) item.category_name = decodeHtmlEntities(split.category_name);
     if (split.budget_id !== undefined) item.budget_id = split.budget_id;
     if (split.tags !== undefined) item.tags = split.tags;
     if (split.notes !== undefined) item.notes = split.notes;

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -219,7 +219,8 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
     {
       title: 'Get Transaction',
       description:
-        'Get a single Firefly III transaction by its numeric ID, including all splits. Use get_transactions to find valid transaction IDs.',
+        'Get a single Firefly III transaction by its numeric ID, including all splits. Use get_transactions to find valid transaction IDs. ' +
+        "The response's top-level `id` is the transaction GROUP id — pass that (not the `transaction_journal_id` nested inside each item of the `transactions` array) to update_transaction or delete_transaction. The two ids are different, usually adjacent numbers, and using the journal id instead of the group id silently edits or deletes a different transaction.",
       inputSchema: {
         id: z.string().describe('Transaction ID'),
       },
@@ -234,7 +235,8 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
     {
       title: 'Create Transaction',
       description:
-        'Create a new transaction in Firefly III. Use get_accounts to find source and destination account IDs.',
+        'Create a new transaction in Firefly III. Use get_accounts to find source and destination account IDs. ' +
+        "The response's top-level `id` is the transaction GROUP id — that's what update_transaction/delete_transaction expect, NOT the `transaction_journal_id` nested inside `transactions[0]` of the same response (a different, usually adjacent, number).",
       inputSchema: {
         type: z.enum(['withdrawal', 'deposit', 'transfer']).describe('Transaction type'),
         date: dateOrDateTimeSchema.describe('Transaction date (YYYY-MM-DD or RFC 3339 date-time with timezone)'),
@@ -261,7 +263,11 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
       description:
         'Update an existing transaction in Firefly III. Only fields provided will be changed. Use get_transaction to confirm the ID before updating.',
       inputSchema: {
-        id: z.string().describe('Transaction ID — use get_transactions to find valid IDs'),
+        id: z
+          .string()
+          .describe(
+            'Transaction GROUP ID — the top-level `id` from a create/get response, NOT the `transaction_journal_id` nested inside its `transactions` array (a different, usually adjacent, number). Passing the journal id silently updates a different transaction. Use get_transactions to find valid group IDs.',
+          ),
         type: z.enum(['withdrawal', 'deposit', 'transfer']).optional().describe('Transaction type'),
         date: dateOrDateTimeSchema
           .optional()
@@ -289,7 +295,11 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
       description:
         'Permanently delete a transaction from Firefly III. **This action cannot be undone.** Use get_transaction to confirm the transaction before deleting.',
       inputSchema: {
-        id: z.string().describe('Transaction ID — use get_transactions to find valid IDs'),
+        id: z
+          .string()
+          .describe(
+            'Transaction GROUP ID — the top-level `id` from a create/get response, NOT the `transaction_journal_id` nested inside its `transactions` array (a different, usually adjacent, number). Passing the journal id silently deletes a different transaction. Use get_transactions to find valid group IDs.',
+          ),
       },
       annotations: DELETE_ANNOTATIONS,
     },


### PR DESCRIPTION
Summary

create_account and update_account were missing liability_type/liability_direction, which Firefly III requires when type=liability — so liability accounts (debt, loan, mortgage) couldn't be created or fixed up through the MCP server at all. This adds both fields as optional zod enums, matching how account_role is already scoped to asset accounts.

Firefly III's API requires liability_type and liability_direction when creating or updating an account with type=liability, but these fields were missing from both tool schemas. Any attempt to create or fix up a liability account (debt, loan, mortgage) failed with a validation error, with no way to supply the required fields.

Adds both as optional zod enum fields (optional since they only apply when type is liability, matching the existing account_role pattern for asset accounts) and threads them through to the Firefly API request body unchanged.

- liability_type: 'loan' | 'debt' | 'mortgage'
- liability_direction: 'credit' | 'debit'

Adds coverage in accounts.test.ts and a CHANGELOG entry under Unreleased.

Type of change

- [x] fix (bug fix)

Checklist

- [x] Tests added or updated
- [x] npm test passes locally
- [x] npx tsc --noEmit passes locally
- [ ] README tool table updated (if a new tool was added) — n/a, no new tool, existing tools' fields only
- [ ] CLAUDE.md updated (if architectural) — n/a, not architectural
- [x] Verified relevant fields against the Firefly III OpenAPI spec (if API-touching) — liability_type/liability_direction and their enum values confirmed against the AccountStore/AccountUpdate schemas