### PR TITLE
fix(accounts): complete liability field support on create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `create_account` and `update_account` now also accept the rest of Firefly III's liability terms: `liability_amount`, `liability_start_date`, `interest`, and `interest_period`. Without them a liability could be created but not given the balance and interest terms that make it useful, and there was no way to correct them afterwards. `interest_period` deliberately offers six periods on create and only `daily`/`monthly`/`yearly` on update, because Firefly III validates the two endpoints against different lists.
+
+### Fixed
+- `create_account` and `update_account` were missing `liability_type` and `liability_direction`, which the Firefly III API requires when `type` is `liability`. Creating or updating a debt/loan/mortgage account failed with a validation error and no way to supply the required fields. Both are now accepted as optional enums on both tools. _Contributed by [@lesha198a](https://github.com/lesha198a) in [#77](https://github.com/daften/fireflyiii-mcp/pull/77)._
+- `update_account` described its liability fields as "required when type is liability", a condition it can never meet — the tool has no `type` field and never sends one. They now read "Only applies to liability accounts", so a model does not skip them expecting a `type` to trigger them.
+
 ### Changed
 - Releases are now cut on a short-lived `release/X.Y.Z` branch that reaches `main` as a single PR, instead of a promotion merge followed by a separate release commit on `main`. Since `backmerge.yml` runs on every push to `main`, the old shape back-merged twice per release; this shape does it once, puts the release commit through CI, and leaves `auto-release.yml` as the only thing committing directly to `main`. `backmerge.yml` itself now merges and pushes to `develop` directly, opening a PR only when the merge conflicts and needs manual resolution.
 - `CHANGELOG.md` now has a `merge=union` driver (`.gitattributes`), so `develop`'s pending `[Unreleased]` entries and `main`'s freshly-cut dated release sections no longer conflict on every back-merge — git keeps both sides automatically instead of failing.
-### Fixed
-- `create_account` and `update_account` were missing `liability_type` and `liability_direction`, which the Firefly III API requires when `type` is `liability`. Creating or updating a debt/loan/mortgage account failed with a validation error and no way to supply the required fields. Both are now accepted as optional enums on both tools.
 
 ## [0.4.2] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Releases are now cut on a short-lived `release/X.Y.Z` branch that reaches `main` as a single PR, instead of a promotion merge followed by a separate release commit on `main`. Since `backmerge.yml` runs on every push to `main`, the old shape back-merged twice per release; this shape does it once, puts the release commit through CI, and leaves `auto-release.yml` as the only thing committing directly to `main`. `backmerge.yml` itself now merges and pushes to `develop` directly, opening a PR only when the merge conflicts and needs manual resolution.
 - `CHANGELOG.md` now has a `merge=union` driver (`.gitattributes`), so `develop`'s pending `[Unreleased]` entries and `main`'s freshly-cut dated release sections no longer conflict on every back-merge — git keeps both sides automatically instead of failing.
+### Fixed
+- `create_account` and `update_account` were missing `liability_type` and `liability_direction`, which the Firefly III API requires when `type` is `liability`. Creating or updating a debt/loan/mortgage account failed with a validation error and no way to supply the required fields. Both are now accepted as optional enums on both tools.
 
 ## [0.4.2] - 2026-08-04
 

--- a/src/tests/accounts.test.ts
+++ b/src/tests/accounts.test.ts
@@ -101,6 +101,21 @@ describe('createAccount', () => {
     const result = await createAccount(mockClient, { name: 'New Account', type: 'asset' });
     expect(result).toEqual({ name: 'New Account', type: 'asset', active: true, id: '10' });
   });
+  it('posts liability_type and liability_direction when type is liability', async () => {
+    mockClient.post = vi.fn().mockResolvedValueOnce(accountSingleFixture);
+    await createAccount(mockClient, {
+      name: 'Credit line',
+      type: 'liability',
+      liability_type: 'debt',
+      liability_direction: 'debit',
+    });
+    expect(mockClient.post).toHaveBeenCalledWith('/accounts', {
+      name: 'Credit line',
+      type: 'liability',
+      liability_type: 'debt',
+      liability_direction: 'debit',
+    });
+  });
 });
 
 describe('updateAccount', () => {
@@ -108,6 +123,14 @@ describe('updateAccount', () => {
     mockClient.put = vi.fn().mockResolvedValueOnce(accountSingleFixture);
     await updateAccount(mockClient, '10', { name: 'Renamed' });
     expect(mockClient.put).toHaveBeenCalledWith('/accounts/10', { name: 'Renamed' });
+  });
+  it('puts liability_type and liability_direction when provided', async () => {
+    mockClient.put = vi.fn().mockResolvedValueOnce(accountSingleFixture);
+    await updateAccount(mockClient, '10', { liability_type: 'loan', liability_direction: 'debit' });
+    expect(mockClient.put).toHaveBeenCalledWith('/accounts/10', {
+      liability_type: 'loan',
+      liability_direction: 'debit',
+    });
   });
   it('returns unwrapped single', async () => {
     mockClient.put = vi.fn().mockResolvedValueOnce(accountSingleFixture);

--- a/src/tests/accounts.test.ts
+++ b/src/tests/accounts.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { z } from 'zod';
 import type { FireflyClient } from '../client.js';
 import {
   clearAccountsCache,
@@ -116,6 +117,29 @@ describe('createAccount', () => {
       liability_direction: 'debit',
     });
   });
+  it('posts the liability amount, start date and interest terms', async () => {
+    mockClient.post = vi.fn().mockResolvedValueOnce(accountSingleFixture);
+    await createAccount(mockClient, {
+      name: 'Mortgage',
+      type: 'liability',
+      liability_type: 'mortgage',
+      liability_direction: 'debit',
+      liability_amount: '250000.00',
+      liability_start_date: '2026-01-01',
+      interest: '3.15',
+      interest_period: 'half-year',
+    });
+    expect(mockClient.post).toHaveBeenCalledWith('/accounts', {
+      name: 'Mortgage',
+      type: 'liability',
+      liability_type: 'mortgage',
+      liability_direction: 'debit',
+      liability_amount: '250000.00',
+      liability_start_date: '2026-01-01',
+      interest: '3.15',
+      interest_period: 'half-year',
+    });
+  });
 });
 
 describe('updateAccount', () => {
@@ -130,6 +154,21 @@ describe('updateAccount', () => {
     expect(mockClient.put).toHaveBeenCalledWith('/accounts/10', {
       liability_type: 'loan',
       liability_direction: 'debit',
+    });
+  });
+  it('puts the liability amount, start date and interest terms when provided', async () => {
+    mockClient.put = vi.fn().mockResolvedValueOnce(accountSingleFixture);
+    await updateAccount(mockClient, '10', {
+      liability_amount: '18000.00',
+      liability_start_date: '2026-03-01',
+      interest: '4.5',
+      interest_period: 'monthly',
+    });
+    expect(mockClient.put).toHaveBeenCalledWith('/accounts/10', {
+      liability_amount: '18000.00',
+      liability_start_date: '2026-03-01',
+      interest: '4.5',
+      interest_period: 'monthly',
     });
   });
   it('returns unwrapped single', async () => {
@@ -191,6 +230,34 @@ describe('searchAccounts', () => {
       page: 1,
       limit: 50,
     });
+  });
+});
+
+describe('liability input schemas', () => {
+  function schemaFor(tool: string): Record<string, z.ZodTypeAny> {
+    const { server, toolConfigs } = createMockServer();
+    registerAccountTools(server, {} as FireflyClient);
+    return toolConfigs.get(tool).inputSchema;
+  }
+
+  // Firefly III validates interest_period against config('firefly.interest_periods') on store but
+  // against a hardcoded `in:daily,monthly,yearly` on update, so the two tools must not offer the
+  // same options — update_account would otherwise advertise values the API rejects.
+  it('offers every Firefly interest period on create and only the three update accepts', () => {
+    const create = schemaFor('create_account').interest_period as z.ZodEnum<any>;
+    const update = schemaFor('update_account').interest_period as z.ZodEnum<any>;
+    expect(create.unwrap().options).toEqual(['daily', 'weekly', 'monthly', 'quarterly', 'half-year', 'yearly']);
+    expect(update.unwrap().options).toEqual(['daily', 'monthly', 'yearly']);
+  });
+
+  // update_account has no `type` field at all, so "required when type is liability" describes a
+  // condition the tool can never meet and only misleads a caller into supplying nothing.
+  it('does not describe update_account liability fields as conditional on a type field', () => {
+    const update = schemaFor('update_account');
+    for (const field of ['liability_type', 'liability_direction', 'liability_amount', 'interest_period']) {
+      expect(update[field].description).not.toMatch(/type is liability/);
+      expect(update[field].description).toMatch(/liability accounts/);
+    }
   });
 });
 

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { FireflyClient } from '../client.js';
-import { createAccount, deleteAccount, fetchAccount, fetchAccounts } from '../tools/accounts.js';
+import { createAccount, deleteAccount, fetchAccount, fetchAccounts, updateAccount } from '../tools/accounts.js';
 import { fetchBudgets } from '../tools/budgets.js';
 import { fetchCategories } from '../tools/categories.js';
 import { fetchCurrencies } from '../tools/currencies.js';
@@ -111,6 +111,68 @@ describe.skipIf(SKIP)('Integration: Firefly III live connection', () => {
       const result = await deleteAccount(client, accountId);
       expect(result.deleted).toBe(true);
       expect(result.id).toBe(accountId);
+    });
+  });
+
+  // ── Liability accounts ─────────────────────────────────────────────────────
+  // create_account and update_account expose different interest_period enums because Firefly III
+  // validates the two endpoints against different lists (see the constants in tools/accounts.ts).
+  // That split, and the liability_amount/liability_start_date pairing, are read off Firefly's
+  // validators rather than any published schema — these are the only assertions that notice if an
+  // upstream release moves them.
+
+  describe('liability accounts', () => {
+    let liabilityId: string;
+
+    afterAll(async () => {
+      if (liabilityId) await deleteAccount(client, liabilityId).catch(() => {});
+    });
+
+    it('can create a liability with its full set of terms', async () => {
+      const result = await createAccount(client, {
+        name: 'CI Test Mortgage',
+        type: 'liability',
+        liability_type: 'mortgage',
+        liability_direction: 'debit',
+        liability_amount: '250000.00',
+        liability_start_date: today,
+        interest: '3.15',
+        interest_period: 'half-year',
+        currency_code: 'EUR',
+      });
+      expect(result).toHaveProperty('id');
+      expect(result).not.toHaveProperty('attributes');
+      expect(result.liability_type).toBe('mortgage');
+      expect(result.liability_direction).toBe('debit');
+      expect(Number(result.interest)).toBeCloseTo(3.15);
+      expect(result.interest_period).toBe('half-year');
+      liabilityId = result.id as string;
+    });
+
+    it('rejects a liability start date sent without its amount', async () => {
+      await expect(
+        createAccount(client, {
+          name: 'CI Test Unpaired Liability',
+          type: 'liability',
+          liability_type: 'debt',
+          liability_direction: 'debit',
+          liability_start_date: today,
+        }),
+      ).rejects.toThrow(/liability_amount/);
+    });
+
+    it('can update the interest terms with a period the update endpoint accepts', async () => {
+      const result = await updateAccount(client, liabilityId, { interest: '4.5', interest_period: 'monthly' });
+      expect(Number(result.interest)).toBeCloseTo(4.5);
+      expect(result.interest_period).toBe('monthly');
+    });
+
+    it('rejects an interest period that only create_account accepts', async () => {
+      // 'quarterly' is in create_account's enum but not update_account's. The cast deliberately
+      // bypasses that split to confirm Firefly enforces it server-side, which is the whole reason
+      // the two tools cannot share one enum.
+      const outOfRange = { interest_period: 'quarterly' } as unknown as Parameters<typeof updateAccount>[2];
+      await expect(updateAccount(client, liabilityId, outOfRange)).rejects.toThrow(/interest_period/);
     });
   });
 

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -43,6 +43,8 @@ export async function createAccount(
     name: string;
     type: 'asset' | 'expense' | 'revenue' | 'liability';
     account_role?: 'defaultAsset' | 'sharedAsset' | 'savingAsset' | 'ccAsset' | 'cashWalletAsset';
+    liability_type?: 'loan' | 'debt' | 'mortgage';
+    liability_direction?: 'credit' | 'debit';
     currency_code?: string;
     iban?: string;
     opening_balance?: string;
@@ -67,6 +69,8 @@ export async function updateAccount(
     include_net_worth?: boolean;
     active?: boolean;
     notes?: string;
+    liability_type?: 'loan' | 'debt' | 'mortgage';
+    liability_direction?: 'credit' | 'debit';
   },
 ): Promise<UnwrappedSingle> {
   const response = await client.put<JsonApiSingleResponse>(`/accounts/${id}`, params);
@@ -183,6 +187,16 @@ export function registerAccountTools(server: McpServer, client: FireflyClient): 
           .enum(['defaultAsset', 'sharedAsset', 'savingAsset', 'ccAsset', 'cashWalletAsset'])
           .optional()
           .describe('Role for asset accounts (required when type is asset)'),
+        liability_type: z
+          .enum(['loan', 'debt', 'mortgage'])
+          .optional()
+          .describe('Liability type (required when type is liability): loan, debt, or mortgage'),
+        liability_direction: z
+          .enum(['credit', 'debit'])
+          .optional()
+          .describe(
+            "Liability direction (required when type is liability): 'debit' if you owe this money, 'credit' if it is owed to you",
+          ),
         currency_code: z.string().optional().describe('Currency code (e.g. EUR, USD)'),
         iban: z.string().optional().describe('IBAN number'),
         opening_balance: z.string().optional().describe('Opening balance as a number string'),
@@ -212,6 +226,16 @@ export function registerAccountTools(server: McpServer, client: FireflyClient): 
         include_net_worth: z.boolean().optional().describe('Include in net worth calculations'),
         active: z.boolean().optional().describe('Whether the account is active'),
         notes: z.string().optional().describe('Notes'),
+        liability_type: z
+          .enum(['loan', 'debt', 'mortgage'])
+          .optional()
+          .describe('Liability type (required when type is liability): loan, debt, or mortgage'),
+        liability_direction: z
+          .enum(['credit', 'debit'])
+          .optional()
+          .describe(
+            "Liability direction (required when type is liability): 'debit' if you owe this money, 'credit' if it is owed to you",
+          ),
       },
       annotations: UPDATE_ANNOTATIONS,
     },

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -37,6 +37,12 @@ export async function fetchAccount(client: FireflyClient, id: string): Promise<U
   return unwrapSingle(response);
 }
 
+// Firefly III validates interest_period against config('firefly.interest_periods') when an account is
+// created, but against a hardcoded `in:daily,monthly,yearly` rule when one is updated. Mirroring that
+// split keeps update_account from advertising four periods the API will reject.
+const CREATE_INTEREST_PERIODS = ['daily', 'weekly', 'monthly', 'quarterly', 'half-year', 'yearly'] as const;
+const UPDATE_INTEREST_PERIODS = ['daily', 'monthly', 'yearly'] as const;
+
 export async function createAccount(
   client: FireflyClient,
   params: {
@@ -45,6 +51,10 @@ export async function createAccount(
     account_role?: 'defaultAsset' | 'sharedAsset' | 'savingAsset' | 'ccAsset' | 'cashWalletAsset';
     liability_type?: 'loan' | 'debt' | 'mortgage';
     liability_direction?: 'credit' | 'debit';
+    liability_amount?: string;
+    liability_start_date?: string;
+    interest?: string;
+    interest_period?: (typeof CREATE_INTEREST_PERIODS)[number];
     currency_code?: string;
     iban?: string;
     opening_balance?: string;
@@ -71,6 +81,10 @@ export async function updateAccount(
     notes?: string;
     liability_type?: 'loan' | 'debt' | 'mortgage';
     liability_direction?: 'credit' | 'debit';
+    liability_amount?: string;
+    liability_start_date?: string;
+    interest?: string;
+    interest_period?: (typeof UPDATE_INTEREST_PERIODS)[number];
   },
 ): Promise<UnwrappedSingle> {
   const response = await client.put<JsonApiSingleResponse>(`/accounts/${id}`, params);
@@ -197,6 +211,25 @@ export function registerAccountTools(server: McpServer, client: FireflyClient): 
           .describe(
             "Liability direction (required when type is liability): 'debit' if you owe this money, 'credit' if it is owed to you",
           ),
+        liability_amount: z
+          .string()
+          .optional()
+          .describe(
+            'Amount of the liability as a number string, for liability accounts. Must be sent together with liability_start_date.',
+          ),
+        liability_start_date: dateSchema
+          .optional()
+          .describe(
+            'Date the liability started (YYYY-MM-DD), for liability accounts. Must be sent together with liability_amount.',
+          ),
+        interest: z
+          .string()
+          .optional()
+          .describe('Interest percentage as a number string between 0 and 100 (e.g. "3.15"), for liability accounts'),
+        interest_period: z
+          .enum(CREATE_INTEREST_PERIODS)
+          .optional()
+          .describe('Period the interest percentage applies to, for liability accounts'),
         currency_code: z.string().optional().describe('Currency code (e.g. EUR, USD)'),
         iban: z.string().optional().describe('IBAN number'),
         opening_balance: z.string().optional().describe('Opening balance as a number string'),
@@ -229,12 +262,33 @@ export function registerAccountTools(server: McpServer, client: FireflyClient): 
         liability_type: z
           .enum(['loan', 'debt', 'mortgage'])
           .optional()
-          .describe('Liability type (required when type is liability): loan, debt, or mortgage'),
+          .describe('Only applies to liability accounts: loan, debt, or mortgage'),
         liability_direction: z
           .enum(['credit', 'debit'])
           .optional()
+          .describe("Only applies to liability accounts: 'debit' if you owe this money, 'credit' if it is owed to you"),
+        liability_amount: z
+          .string()
+          .optional()
           .describe(
-            "Liability direction (required when type is liability): 'debit' if you owe this money, 'credit' if it is owed to you",
+            'Only applies to liability accounts: amount of the liability as a number string. Must be sent together with liability_start_date.',
+          ),
+        liability_start_date: dateSchema
+          .optional()
+          .describe(
+            'Only applies to liability accounts: date the liability started (YYYY-MM-DD). Must be sent together with liability_amount.',
+          ),
+        interest: z
+          .string()
+          .optional()
+          .describe(
+            'Only applies to liability accounts: interest percentage as a number string between 0 and 100 (e.g. "3.15")',
+          ),
+        interest_period: z
+          .enum(UPDATE_INTEREST_PERIODS)
+          .optional()
+          .describe(
+            'Only applies to liability accounts: period the interest percentage applies to. Firefly III accepts fewer periods here than on create_account.',
           ),
       },
       annotations: UPDATE_ANNOTATIONS,


### PR DESCRIPTION
## Summary

Split off from #77, which bundled three unrelated changes into one branch. This is the core one: the liability fields on `create_account` / `update_account`.

The first commit is @lesha198a's original, cherry-picked unchanged so authorship and credit survive the merge. The second commit is mine, applying the review feedback from #77 plus the extra liability fields discussed there.

## What's in it

**`fix(accounts): add liability_type/liability_direction` (@lesha198a)** — the original fix. Firefly III requires both when `type` is `liability`, and neither tool exposed them, so a debt/loan/mortgage account could not be created or repaired through the MCP server at all.

**`feat(accounts): complete the liability field set on create/update`** — follow-up:

- Adds `liability_amount`, `liability_start_date`, `interest`, and `interest_period` to both tools. Without them a liability lands with no balance and no terms, and nothing can fix it up afterwards.
- Rewords `update_account`'s liability descriptions. They said "required when type is liability", but `update_account` has no `type` field and never sends one, so the condition can never be met — a model reading it has no reason to supply the fields at all. They now read "Only applies to liability accounts".

## One thing worth reviewing

Fields were checked against Firefly III's actual validators rather than the generated docs, which surfaced a real asymmetry:

- `AccountStoreRequest`: `'interest_period' => sprintf('nullable|in:%s', implode(',', config('firefly.interest_periods')))` → `daily, weekly, monthly, quarterly, half-year, yearly`
- `AccountUpdateRequest`: `'interest_period' => ['required_if:type,liability', 'in:daily,monthly,yearly']`

So the two endpoints accept different lists. `create_account` offers six periods and `update_account` offers three; a shared enum would advertise four values the update endpoint rejects. There's a test pinning both lists and a comment at the constants explaining why they differ.

Also confirmed `liability_amount` and `liability_start_date` are `required_with` each other, so both descriptions say to send them as a pair.

## Type of change

- [x] fix (bug fix)
- [x] feat (new fields on existing tools)

## Checklist

- [x] Tests added or updated
- [x] `npm test` passes locally (444 passed, 13 skipped)
- [x] `npx tsc --noEmit` passes locally
- [x] `npx biome check src/` passes locally
- [ ] README tool table updated (if a new tool was added) — n/a, no new tool
- [ ] CLAUDE.md updated (if architectural) — n/a
- [x] Verified relevant fields against the Firefly III OpenAPI spec (if API-touching) — verified against `AccountStoreRequest`/`AccountUpdateRequest` in firefly-iii, which is what the spec is generated from
