### PR TITLE
docs(transactions): warn against transaction_journal_id in id fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Releases are now cut on a short-lived `release/X.Y.Z` branch that reaches `main` as a single PR, instead of a promotion merge followed by a separate release commit on `main`. Since `backmerge.yml` runs on every push to `main`, the old shape back-merged twice per release; this shape does it once, puts the release commit through CI, and leaves `auto-release.yml` as the only thing committing directly to `main`. `backmerge.yml` itself now merges and pushes to `develop` directly, opening a PR only when the merge conflicts and needs manual resolution.
 - `CHANGELOG.md` now has a `merge=union` driver (`.gitattributes`), so `develop`'s pending `[Unreleased]` entries and `main`'s freshly-cut dated release sections no longer conflict on every back-merge — git keeps both sides automatically instead of failing.
 
+### Changed
+- `get_transaction`, `create_transaction`, `update_transaction`, and `delete_transaction` now explicitly warn in their descriptions that a transaction response's top-level `id` (the transaction GROUP id) is what update/delete expect — not the `transaction_journal_id` nested inside each item of the response's `transactions` array, a different, usually adjacent, number. Passing the journal id previously silently edited or deleted an unrelated transaction with no error.
+
 ## [0.4.2] - 2026-08-04
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `get_transaction`, `create_transaction`, `update_transaction`, and `delete_transaction` now warn in their descriptions that update and delete take the transaction response's top-level group `id`, not the `transaction_journal_id` nested inside each item of its `transactions` array. The two are usually adjacent numbers, so passing the journal id silently edited or deleted a real but unrelated transaction instead of failing. It stays a warning rather than a check because nothing at write time can tell a group id from a journal id. _Contributed by [@lesha198a](https://github.com/lesha198a) in [#77](https://github.com/daften/fireflyiii-mcp/pull/77)._
 - Releases are now cut on a short-lived `release/X.Y.Z` branch that reaches `main` as a single PR, instead of a promotion merge followed by a separate release commit on `main`. Since `backmerge.yml` runs on every push to `main`, the old shape back-merged twice per release; this shape does it once, puts the release commit through CI, and leaves `auto-release.yml` as the only thing committing directly to `main`. `backmerge.yml` itself now merges and pushes to `develop` directly, opening a PR only when the merge conflicts and needs manual resolution.
 - `CHANGELOG.md` now has a `merge=union` driver (`.gitattributes`), so `develop`'s pending `[Unreleased]` entries and `main`'s freshly-cut dated release sections no longer conflict on every back-merge — git keeps both sides automatically instead of failing.
-
-### Changed
-- `get_transaction`, `create_transaction`, `update_transaction`, and `delete_transaction` now explicitly warn in their descriptions that a transaction response's top-level `id` (the transaction GROUP id) is what update/delete expect — not the `transaction_journal_id` nested inside each item of the response's `transactions` array, a different, usually adjacent, number. Passing the journal id previously silently edited or deleted an unrelated transaction with no error.
 
 ## [0.4.2] - 2026-08-04
 

--- a/src/tests/transactions.test.ts
+++ b/src/tests/transactions.test.ts
@@ -310,4 +310,22 @@ describe('handler smoke — transactions', () => {
     const result = await handlers.get('get_transactions')!({});
     expect(result).toMatchObject({ isError: true });
   });
+
+  // Regression test for a real mistake: transaction responses carry two different ids — the
+  // top-level group `id` (what update/delete expect) and a `transaction_journal_id` nested inside
+  // each item of `transactions[]` (usually an adjacent number). Passing the journal id to
+  // update_transaction/delete_transaction silently edits or deletes a different transaction. These
+  // assertions make sure the warning stays present if the tool descriptions are ever reworded.
+  it('warns against transaction_journal_id in id-accepting tool descriptions', () => {
+    const { server, toolConfigs } = createMockServer();
+    registerTransactionTools(server, {} as unknown as FireflyClient);
+    for (const name of ['get_transaction', 'create_transaction', 'update_transaction', 'delete_transaction']) {
+      const config = toolConfigs.get(name);
+      const text =
+        name === 'update_transaction' || name === 'delete_transaction'
+          ? config.inputSchema.id.description
+          : config.description;
+      expect(text, `${name} should warn about transaction_journal_id`).toContain('transaction_journal_id');
+    }
+  });
 });

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -13,6 +13,17 @@ import type { QueryParams } from '../types.js';
 import { DELETE_ANNOTATIONS, READ_ANNOTATIONS, UPDATE_ANNOTATIONS, WRITE_ANNOTATIONS } from './_annotations.js';
 import { dateOrDateTimeSchema, dateSchema, defineTool } from './_helpers.js';
 
+// A transaction response carries two ids: the top-level group `id`, which update_transaction and
+// delete_transaction expect, and a `transaction_journal_id` inside each item of `transactions[]`.
+// They are usually adjacent numbers, so the wrong one addresses a real but unrelated transaction
+// rather than erroring — nothing at write time can tell the two apart, which is why these fields
+// warn instead of validating.
+const GROUP_ID_HINT =
+  'update_transaction and delete_transaction take the top-level `id` (the transaction group), not the `transaction_journal_id` inside `transactions[]`.';
+
+const groupIdField = (verb: string): string =>
+  `Transaction group ID — the top-level \`id\` from get_transaction, not the \`transaction_journal_id\` inside \`transactions[]\`. That is usually an adjacent number, so the wrong one silently ${verb} a different transaction.`;
+
 export async function fetchTransactions(
   client: FireflyClient,
   params: {
@@ -218,9 +229,7 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
     'get_transaction',
     {
       title: 'Get Transaction',
-      description:
-        'Get a single Firefly III transaction by its numeric ID, including all splits. Use get_transactions to find valid transaction IDs. ' +
-        "The response's top-level `id` is the transaction GROUP id — pass that (not the `transaction_journal_id` nested inside each item of the `transactions` array) to update_transaction or delete_transaction. The two ids are different, usually adjacent numbers, and using the journal id instead of the group id silently edits or deletes a different transaction.",
+      description: `Get a single Firefly III transaction by its numeric ID, including all splits. Use get_transactions to find valid transaction IDs. ${GROUP_ID_HINT}`,
       inputSchema: {
         id: z.string().describe('Transaction ID'),
       },
@@ -234,9 +243,7 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
     'create_transaction',
     {
       title: 'Create Transaction',
-      description:
-        'Create a new transaction in Firefly III. Use get_accounts to find source and destination account IDs. ' +
-        "The response's top-level `id` is the transaction GROUP id — that's what update_transaction/delete_transaction expect, NOT the `transaction_journal_id` nested inside `transactions[0]` of the same response (a different, usually adjacent, number).",
+      description: `Create a new transaction in Firefly III. Use get_accounts to find source and destination account IDs. ${GROUP_ID_HINT}`,
       inputSchema: {
         type: z.enum(['withdrawal', 'deposit', 'transfer']).describe('Transaction type'),
         date: dateOrDateTimeSchema.describe('Transaction date (YYYY-MM-DD or RFC 3339 date-time with timezone)'),
@@ -263,11 +270,7 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
       description:
         'Update an existing transaction in Firefly III. Only fields provided will be changed. Use get_transaction to confirm the ID before updating.',
       inputSchema: {
-        id: z
-          .string()
-          .describe(
-            'Transaction GROUP ID — the top-level `id` from a create/get response, NOT the `transaction_journal_id` nested inside its `transactions` array (a different, usually adjacent, number). Passing the journal id silently updates a different transaction. Use get_transactions to find valid group IDs.',
-          ),
+        id: z.string().describe(groupIdField('updates')),
         type: z.enum(['withdrawal', 'deposit', 'transfer']).optional().describe('Transaction type'),
         date: dateOrDateTimeSchema
           .optional()
@@ -295,11 +298,7 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
       description:
         'Permanently delete a transaction from Firefly III. **This action cannot be undone.** Use get_transaction to confirm the transaction before deleting.',
       inputSchema: {
-        id: z
-          .string()
-          .describe(
-            'Transaction GROUP ID — the top-level `id` from a create/get response, NOT the `transaction_journal_id` nested inside its `transactions` array (a different, usually adjacent, number). Passing the journal id silently deletes a different transaction. Use get_transactions to find valid group IDs.',
-          ),
+        id: z.string().describe(groupIdField('deletes')),
       },
       annotations: DELETE_ANNOTATIONS,
     },

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -219,7 +219,8 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
     {
       title: 'Get Transaction',
       description:
-        'Get a single Firefly III transaction by its numeric ID, including all splits. Use get_transactions to find valid transaction IDs.',
+        'Get a single Firefly III transaction by its numeric ID, including all splits. Use get_transactions to find valid transaction IDs. ' +
+        "The response's top-level `id` is the transaction GROUP id — pass that (not the `transaction_journal_id` nested inside each item of the `transactions` array) to update_transaction or delete_transaction. The two ids are different, usually adjacent numbers, and using the journal id instead of the group id silently edits or deletes a different transaction.",
       inputSchema: {
         id: z.string().describe('Transaction ID'),
       },
@@ -234,7 +235,8 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
     {
       title: 'Create Transaction',
       description:
-        'Create a new transaction in Firefly III. Use get_accounts to find source and destination account IDs.',
+        'Create a new transaction in Firefly III. Use get_accounts to find source and destination account IDs. ' +
+        "The response's top-level `id` is the transaction GROUP id — that's what update_transaction/delete_transaction expect, NOT the `transaction_journal_id` nested inside `transactions[0]` of the same response (a different, usually adjacent, number).",
       inputSchema: {
         type: z.enum(['withdrawal', 'deposit', 'transfer']).describe('Transaction type'),
         date: dateOrDateTimeSchema.describe('Transaction date (YYYY-MM-DD or RFC 3339 date-time with timezone)'),
@@ -261,7 +263,11 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
       description:
         'Update an existing transaction in Firefly III. Only fields provided will be changed. Use get_transaction to confirm the ID before updating.',
       inputSchema: {
-        id: z.string().describe('Transaction ID — use get_transactions to find valid IDs'),
+        id: z
+          .string()
+          .describe(
+            'Transaction GROUP ID — the top-level `id` from a create/get response, NOT the `transaction_journal_id` nested inside its `transactions` array (a different, usually adjacent, number). Passing the journal id silently updates a different transaction. Use get_transactions to find valid group IDs.',
+          ),
         type: z.enum(['withdrawal', 'deposit', 'transfer']).optional().describe('Transaction type'),
         date: dateOrDateTimeSchema
           .optional()
@@ -289,7 +295,11 @@ export function registerTransactionTools(server: McpServer, client: FireflyClien
       description:
         'Permanently delete a transaction from Firefly III. **This action cannot be undone.** Use get_transaction to confirm the transaction before deleting.',
       inputSchema: {
-        id: z.string().describe('Transaction ID — use get_transactions to find valid IDs'),
+        id: z
+          .string()
+          .describe(
+            'Transaction GROUP ID — the top-level `id` from a create/get response, NOT the `transaction_journal_id` nested inside its `transactions` array (a different, usually adjacent, number). Passing the journal id silently deletes a different transaction. Use get_transactions to find valid group IDs.',
+          ),
       },
       annotations: DELETE_ANNOTATIONS,
     },


### PR DESCRIPTION
## Summary

Split off from #77, which bundled three unrelated changes into one branch. This is the transaction-id documentation one.

The first commit is @lesha198a's original, cherry-picked unchanged so authorship and credit survive the merge. The second commit is mine, addressing the "these descriptions are longer than all the others" point from the #77 review.

## What's in it

**`docs(transactions): warn against transaction_journal_id in id fields` (@lesha198a)** — the original change. A transaction response carries two ids: the top-level group `id`, which `update_transaction`/`delete_transaction` expect, and a `transaction_journal_id` nested inside each item of `transactions[]`. They are usually adjacent numbers, so passing the journal id addresses a real but unrelated transaction instead of erroring.

**`docs(transactions): tighten the transaction_journal_id warning`** — collapses the four warnings into one shared 150-character `GROUP_ID_HINT` sentence on `get_transaction`/`create_transaction` and a `groupIdField('updates' | 'deletes')` line on the two id fields. The group-vs-journal distinction and the "silently hits a different transaction" consequence both survive; the original was roughly four times the length of every neighbouring description, which crowds out the rest of the schema when a model reads the tool list.

His regression test still passes unchanged — it asserts the descriptions mention `transaction_journal_id`, not their exact wording.

## On adding a runtime guard

Raised in the #77 review, and deliberately not done here. A journal id is a plain integer that is usually *also* a valid group id, so `GET /transactions/{id}` returns a real transaction group either way — there is nothing to validate the id against at write time without a heuristic that guesses. That is exactly why it has to be a warning. A confirm-before-write flow would work, but it is a larger design change than this PR and would apply to more than transactions.

## Type of change

- [x] docs (documentation only)

## Checklist

- [x] Tests added or updated — regression test asserts the warning stays present
- [x] `npm test` passes locally (439 passed, 13 skipped)
- [x] `npx tsc --noEmit` passes locally
- [x] `npx biome check src/` passes locally
- [ ] README tool table updated (if a new tool was added) — n/a
- [ ] CLAUDE.md updated (if architectural) — n/a
- [ ] Verified relevant fields against the Firefly III OpenAPI spec (if API-touching) — n/a, description text only
